### PR TITLE
Feature: add the effects label

### DIFF
--- a/ats/synthetic_data.py
+++ b/ats/synthetic_data.py
@@ -63,7 +63,8 @@ def generate_synthetic_humitemp_timeseries(sampling_interval,time_boundaries=[],
     temp = []
     humi = []
     time = []
-    anomaly_label = [] 
+    anomaly_label = []
+    effect_label = []
      
     data_points = {}
 
@@ -83,6 +84,7 @@ def generate_synthetic_humitemp_timeseries(sampling_interval,time_boundaries=[],
     while time_value < time_boundaries[1]:
         
         anomaly_label.append('normal')
+        effect_label.append('bare')
         time.append(time_value)
         
         time_variable = time_value.hour + time_value.minute/60
@@ -98,6 +100,7 @@ def generate_synthetic_humitemp_timeseries(sampling_interval,time_boundaries=[],
 
     data_points.update({'time': time})
     data_points.update({'anomaly_label': anomaly_label})
+    data_points.update({'effect_label': effect_label})
         
     if temperature:
         data_points.update({'temperature': temp})
@@ -108,7 +111,6 @@ def generate_synthetic_humitemp_timeseries(sampling_interval,time_boundaries=[],
         raise ValueError('Error: no data selected for creating the DataFrame. Set at True at least one of the two arguments: temperature or humidity')
         
     return pd.DataFrame(data_points)
-
 
                                             #anomalies
 

--- a/ats/synthetic_data.py
+++ b/ats/synthetic_data.py
@@ -126,6 +126,7 @@ def add_step_anomaly(timeseries,mode='uv',inplace=False):
     quantities = list(timeseries.columns)
     quantities.remove('time')
     quantities.remove('anomaly_label')
+    quantities.remove('effect_label')
         
     
     ramp_height = 10
@@ -201,6 +202,7 @@ def add_anomalous_noise(timeseries,inplace=False,mode='uv'):
     quantities = list(timeseries.columns)
     quantities.remove('time')
     quantities.remove('anomaly_label')
+    quantities.remove('effect_label')
         
 
     def insert_anomalous_noise(quantity,mode):
@@ -242,6 +244,7 @@ def add_pattern_anomaly(timeseries,sampling_interval,inplace=False,mode='uv'):
     quantities = list(timeseries.columns)
     quantities.remove('time')
     quantities.remove('anomaly_label')
+    quantities.remove('effect_label')
         
     start = int(len(timeseries)/3)
     anomalous_pattern_length = int(len(timeseries)/5)#piece of series with anomalous periodicity
@@ -343,6 +346,7 @@ def add_noise_effect(timeseries,inplace=False):
     quantities = list(timeseries.columns)
     quantities.remove('time')
     quantities.remove('anomaly_label')
+    quantities.remove('effect_label')
 
     for quantity in quantities:
         
@@ -361,6 +365,7 @@ def add_seasons_effect(timeseries,starting_year,inplace=False):
     quantities = list(timeseries.columns)
     quantities.remove('time')
     quantities.remove('anomaly_label')
+    quantities.remove('effect_label')
     
     winter_temp = 4.4
     summer_temp = 26
@@ -405,6 +410,7 @@ def add_clouds_effects(timeseries,sampling_interval,inplace=False,mv_anomaly=Fal
     quantities = list(timeseries.columns)
     quantities.remove('time')
     quantities.remove('anomaly_label')
+    quantities.remove('effect_label')
         
     number_of_points_in_a_day = int(86400/(sampling_interval.total_seconds()))
     if number_of_points_in_a_day == 0:
@@ -456,6 +462,7 @@ def add_spike_effect(timeseries,inplace=False,anomaly=False, mode='uv'):
     quantities = list(timeseries.columns)
     quantities.remove('time')
     quantities.remove('anomaly_label')
+    quantities.remove('effect_label')
     
     spike_factor = { 'low': 5,
                     'medium': 7,
@@ -516,6 +523,7 @@ def csv_file_maker(timeseries,anomalies=[],effects=[],path=''):
     quantities = list(timeseries.columns)
     quantities.remove('time')
     quantities.remove('anomaly_label')
+    quantities.remove('effect_label')
     
     data_type = ''
     for quantity in quantities:
@@ -543,6 +551,7 @@ def plot_func(timeseries,anomalies=[]):
     quantities = list(timeseries.columns)
     quantities.remove('time')
     quantities.remove('anomaly_label')
+    quantities.remove('effect_label')
 
     colors = { 'temperature': 'crimson',
               'humidity': 'navy'

--- a/ats/tests/test_synthetic_data.py
+++ b/ats/tests/test_synthetic_data.py
@@ -58,6 +58,8 @@ class TestSyntheticHumiTempTimeseriesGenerator(unittest.TestCase):
         self.assertEqual(default_timeseries_df.loc[474,'anomaly_label'],'spike_uv')
         for i in range(2160,2836):
             self.assertEqual(default_timeseries_df.loc[i,'anomaly_label'],'step_uv')
+
+        
             
             
            
@@ -482,4 +484,10 @@ class TestSyntheticHumiTempTimeseriesGenerator(unittest.TestCase):
         self.assertAlmostEqual(mv_temp_diff,5)
         self.assertAlmostEqual(mv_humi_diff,5)
         #TODO: a way for knowing the intensity of the espected spike
+
+    def test_default_effect_label(self):
+        bare_timeseries_generator = SyntheticHumiTempTimeseriesGenerator()
+        bare_timeseries_df = bare_timeseries_generator.generate(effects=[],anomalies=[])
+        self.assertEqual(bare_timeseries_df.loc[10,'effect_label'],'bare')
+        
         


### PR DESCRIPTION
Now the generated timeseries has a new column "effect_label" aimed to mark with a string the added effects for each datapoint. The timeseries generated by the function  "generate_synthetic_humitemp_timeseries" is without both effects and anomalies, so the default value for each data point in the column "effect_label" is set to "bare" (following the same logic previously used for the "anomaly_label", that has "normal" as a default value instead). 
Inside functions aimed to add anomalies and effects  the following strategy is used to know how many quantities there are in the timeseries: a list of its columns is made and then the unusefull ones are removed ("time", "anomaly_label" and now also "effect_label"). 
In this moment is not possible to change the effect label inside the functions which add effects, because this would require a refactor of the functions structure. Because of this, only a simple test ensuring if the right default effect label is set was added. 