### PR TITLE
Fix the spike anomaly

### DIFF
--- a/ats/synthetic_data.py
+++ b/ats/synthetic_data.py
@@ -481,11 +481,12 @@ def add_spike_effect(timeseries,inplace=False,anomaly=False, mode='uv'):
                     timeseries.loc[i,'temperature'] += spike_factor[random_spike_intensity]                    
                 
                 if 'humidity' in quantities:
-                    timeseries.loc[i,'humidity'] -= spike_factor[random_spike_intensity]
+                    if (number_of_spikes % 2) == 0:
+                        timeseries.loc[i,'humidity'] -= spike_factor[random_spike_intensity]
+                    else:
+                        timeseries.loc[i,'humidity'] += spike_factor[random_spike_intensity]
 
-                 
             if anomaly and number_of_spikes == 10:
-                number_of_spikes = 0
                 anomaly = False
                 if 'temperature' in quantities and 'humidity' in quantities:
                     if mode == 'uv':


### PR DESCRIPTION
The spike effect was thought to be different in temperature and humidity, in order to design a specific multivariate anomaly based on the presence of spiked values. Before the spike effect was added in the same way for both temperature and humidity (only upward spikes). Now the spike effect is how it was supposed to be (only upward spikes for temperature and both downward and upward for humidity ).  
In the function "add_spike_effect" there is a counter for the number of spikes: when its value is even, the spike is downward, when it is odd the spike is upward. 