### PR TITLE
Feature: minmax anomaly detector evaluator

### DIFF
--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -41,5 +41,8 @@ def evaluate_anomaly_detector(anomaly_detector, evaluation_timeseries_df, synthe
         if anomaly_label_counts == 0:
             evaluation_results[anomaly_label] = False
 
+    if 'normal' in evaluation_results.keys():
+        evaluation_results['false positive'] = evaluation_results.pop('normal')
+
     return evaluation_results
 

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -9,7 +9,7 @@ def evaluate_anomaly_detector(anomaly_detector, evaluation_timeseries_df, synthe
     if 'anomaly_label' not in evaluation_timeseries_df.columns:
         raise ValueError('The anomaly_label column is missing: it is necessary for evaluation')
     # Series with anomaly labels of data pints
-    anomaly_labels = evaluation_timeseries_df['anomaly_label'] 
+    anomaly_labels = evaluation_timeseries_df['anomaly_label']
 
     if synthetic:
         no_flag_timeseries_df = evaluation_timeseries_df.drop(columns=['anomaly_label','effect_label'])
@@ -25,8 +25,7 @@ def evaluate_anomaly_detector(anomaly_detector, evaluation_timeseries_df, synthe
         for raw in range(len(evaluated_timeseries_df)):
 
             if anomaly_labels.iloc[raw] == anomaly_label:
-                # evaluation_results is a dict of series of bool
-                evaluation_results[anomaly_label] = evaluated_anomaly_flags.iloc[raw].isin([1])
+                evaluation_results[anomaly_label] = evaluated_anomaly_flags.iloc[[raw]].isin([1])
                 break
 
     return evaluation_results

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -12,7 +12,7 @@ def evaluate_anomaly_detector(anomaly_detector, evaluation_timeseries_df, synthe
     anomaly_labels = evaluation_timeseries_df['anomaly_label']
 
     if synthetic:
-        no_flag_timeseries_df = evaluation_timeseries_df.drop(columns=['anomaly_label','effect_label'])
+        no_flag_timeseries_df = evaluation_timeseries_df.drop(columns=['time','anomaly_label','effect_label'])
     else:
         no_flag_timeseries_df = evaluation_timeseries_df.drop(columns=['anomaly_label'])
 

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -27,7 +27,7 @@ def evaluate_anomaly_detector(anomaly_detector, evaluation_timeseries_df, synthe
 
             if anomaly_labels.loc[time_index] == anomaly_label:
                 row_evaluation_df = evaluated_anomaly_flags.loc[[time_index],:].isin([1])
-                for column in raw_evaluation_df.columns:
+                for column in row_evaluation_df.columns:
 
                     if row_evaluation_df.loc[time_index,column] == True:
                         if anomaly_label_counts == 0:

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -42,7 +42,7 @@ def evaluate_anomaly_detector(anomaly_detector, evaluation_timeseries_df, synthe
             evaluation_results[anomaly_label] = False
 
     if 'normal' in evaluation_results.keys():
-        evaluation_results['false positive'] = evaluation_results.pop('normal')
+        evaluation_results['false_positives'] = evaluation_results.pop('normal')
 
     return evaluation_results
 

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -1,0 +1,33 @@
+from .anomaly_detectors import MinMaxAnomalyDetector
+
+
+def evaluate_anomaly_detector(anomaly_detector, evaluation_timeseries_df, synthetic=False):
+
+    if not isinstance(anomaly_detector,MinMaxAnomalyDetector):
+        raise ValueError('Only MinMaxAnomalyDetector is supported')
+
+    if 'anomaly_label' not in evaluation_timeseries_df.columns:
+        raise ValueError('The anomaly_label column is missing: it is necessary for evaluation')
+    # Series with anomaly labels of data pints
+    anomaly_labels = evaluation_timeseries_df['anomaly_label'] 
+
+    if synthetic:
+        no_flag_timeseries_df = evaluation_timeseries_df.drop(columns=['anomaly_label','effect_label'])
+    else:
+        no_flag_timeseries_df = evaluation_timeseries_df.drop(columns=['anomaly_label'])
+
+    evaluated_timeseries_df = anomaly_detector.apply(no_flag_timeseries_df)
+    evaluated_anomaly_flags = evaluated_timeseries_df.filter(like='_anomaly')
+    evaluation_results = {}
+
+    for anomaly_label,frequency in anomaly_labels.value_counts().items():
+
+        for raw in range(len(evaluated_timeseries_df)):
+
+            if anomaly_labels.iloc[raw] == anomaly_label:
+                # evaluation_results is a dict of series of bool
+                evaluation_results[anomaly_label] = evaluated_anomaly_flags.iloc[raw].isin([1])
+                break
+
+    return evaluation_results
+

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -26,14 +26,14 @@ def evaluate_anomaly_detector(anomaly_detector, evaluation_timeseries_df, synthe
         for time_index in evaluated_timeseries_df.index:
 
             if anomaly_labels.loc[time_index] == anomaly_label:
-                raw_evaluation_df = evaluated_anomaly_flags.loc[[time_index],:].isin([1])
+                row_evaluation_df = evaluated_anomaly_flags.loc[[time_index],:].isin([1])
                 for column in raw_evaluation_df.columns:
 
-                    if raw_evaluation_df.loc[time_index,column] == True:
+                    if row_evaluation_df.loc[time_index,column] == True:
                         if anomaly_label_counts == 0:
-                            evaluation_results[anomaly_label] = raw_evaluation_df
+                            evaluation_results[anomaly_label] = row_evaluation_df
                         else:
-                            evaluation_results[anomaly_label] = pd.concat([evaluation_results[anomaly_label],raw_evaluation_df],ignore_index=False)
+                            evaluation_results[anomaly_label] = pd.concat([evaluation_results[anomaly_label],row_evaluation_df],ignore_index=False)
 
                         anomaly_label_counts += 1
                         break

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -56,7 +56,7 @@ class TestEvaluators(unittest.TestCase):
     def test_evaluate_anomaly_det_on_spiked_synth_timeseries(self):
 
         spiked_humi_temp_generator = SyntheticHumiTempTimeseriesGenerator()
-        spiked_humi_temp_df = spiked_humi_temp_generator.generate(anomalies=['spike_uv'],effects=[])
+        humi_temp_df = spiked_humi_temp_generator.generate(anomalies=['spike_uv'],effects=[])
         # Generated DataFrame:
         # Timestamp                    temperature           humidity             anomaly_label    effect_label
         # ...
@@ -68,17 +68,17 @@ class TestEvaluators(unittest.TestCase):
         # 1973-05-07 12:17:00+00:00    24.979376388246145    50.05499629801029    normal           bare
         # 1973-05-07 12:32:00+00:00    24.927010515561776    50.194638625168594   normal           bare
         # ...
-        max_temp_index = spiked_humi_temp_df['temperature'].idxmax()
-        min_temp_index = spiked_humi_temp_df['temperature'].idxmin()
-        max_humi_index = spiked_humi_temp_df['humidity'].idxmax()
-        min_humi_index = spiked_humi_temp_df['humidity'].idxmin()
-        label_detected_anomalous_temp1 = spiked_humi_temp_df.loc[max_temp_index,'anomaly_label']
-        label_detected_anomalous_temp2 = spiked_humi_temp_df.loc[min_temp_index,'anomaly_label']
-        label_detected_anomalous_humi1 = spiked_humi_temp_df.loc[max_humi_index,'anomaly_label']
-        label_detected_anomalous_humi2 = spiked_humi_temp_df.loc[min_humi_index,'anomaly_label']
+        max_temp_index = humi_temp_df['temperature'].idxmax()
+        min_temp_index = humi_temp_df['temperature'].idxmin()
+        max_humi_index = humi_temp_df['humidity'].idxmax()
+        min_humi_index = humi_temp_df['humidity'].idxmin()
+        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label']
+        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label']
+        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label']
+        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label']
 
         min_max_anomaly_detector = MinMaxAnomalyDetector()
-        evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, spiked_humi_temp_df, synthetic=True)
+        evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, humi_temp_df, synthetic=True)
         self.assertEqual(len(evaluation_results),2)
         self.assertIsInstance(evaluation_results[label_detected_anomalous_temp1],pd.DataFrame)
         self.assertIsInstance(evaluation_results[label_detected_anomalous_temp2],pd.DataFrame)
@@ -129,5 +129,37 @@ class TestEvaluators(unittest.TestCase):
         #
         # 'step_uv':                                  temperature_anomaly   humidity_anomaly
         #               1973-05-26 12:02:00+00:00     True                  True
+        # }
+
+    def test_evaluate_anomaly_det_on_synth_not_anomalous_timeseries(self):
+        humi_temp_generator = SyntheticHumiTempTimeseriesGenerator()
+        humi_temp_df = humi_temp_generator.generate(anomalies=[],effects=[])
+        # Generated DataFrame:
+        # Timestamp                    temperature           humidity             anomaly_label    effect_label
+        # ...
+        # 1973-05-07 11:02:00+00:00    24.761107302835810    50.63704719243785    normal           bare
+        # 1973-05-07 11:17:00+00:00    24.868377982941322    50.350992045489804   normal           bare
+        # 1973-05-07 11:32:00+00:00    24.944096137309916    50.14907696717356    normal           bare
+        # ...
+        max_temp_index = humi_temp_df['temperature'].idxmax()
+        min_temp_index = humi_temp_df['temperature'].idxmin()
+        max_humi_index = humi_temp_df['humidity'].idxmax()
+        min_humi_index = humi_temp_df['humidity'].idxmin()
+        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label']
+        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label']
+        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label']
+        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label']
+
+        min_max_anomaly_detector = MinMaxAnomalyDetector()
+        evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, humi_temp_df, synthetic=True)
+        self.assertEqual(len(evaluation_results),1)
+        self.assertIsInstance(evaluation_results[label_detected_anomalous_temp1],pd.DataFrame)
+        self.assertIsInstance(evaluation_results[label_detected_anomalous_temp2],pd.DataFrame)
+        self.assertIsInstance(evaluation_results[label_detected_anomalous_humi1],pd.DataFrame)
+        self.assertIsInstance(evaluation_results[label_detected_anomalous_humi2],pd.DataFrame)
+        # Evaluation results:
+        # { 'normal':                              temperature_anomaly  humidity_anomaly
+        #            1973-05-03 00:02:00+00:00     True                 True
+        #            1973-05-03 12:02:00+00:00     True                 True
         # }
 

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -34,8 +34,8 @@ class TestEvaluators(unittest.TestCase):
         
         evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, timeseries_df)
         # Evaluation_results
-        #{'normal':      timestamp                   value_anomaly
-        #                2025-06-10 15:00:00+00:00   False,
+        #{'false_positives':      timestamp                   value_anomaly
+        #                         2025-06-10 15:00:00+00:00   False,
         #
         #                timestamp                   value_anomaly
         # 'anomaly_1':   2025-06-10 15:00:00+00:00   True,
@@ -48,10 +48,10 @@ class TestEvaluators(unittest.TestCase):
         self.assertEqual(len(evaluation_results),3)
         self.assertIsInstance(evaluation_results['anomaly_1'],pd.DataFrame)
         self.assertIsInstance(evaluation_results['anomaly_2'],pd.DataFrame)
-        self.assertIsInstance(evaluation_results['false positive'],bool)
+        self.assertIsInstance(evaluation_results['false_positives'],bool)
         self.assertEqual(evaluation_results['anomaly_2'].loc['2025-06-10 16:00:00+00:00','value_anomaly'],True)
         self.assertEqual(evaluation_results['anomaly_1'].loc['2025-06-10 14:00:00+00:00','value_anomaly'],True)
-        self.assertEqual(evaluation_results['false positive'],False)
+        self.assertEqual(evaluation_results['false_positives'],False)
 
     def test_evaluate_anomaly_det_on_spiked_synth_timeseries(self):
 
@@ -72,10 +72,10 @@ class TestEvaluators(unittest.TestCase):
         min_temp_index = humi_temp_df['temperature'].idxmin()
         max_humi_index = humi_temp_df['humidity'].idxmax()
         min_humi_index = humi_temp_df['humidity'].idxmin()
-        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label'] if humi_temp_df.loc[max_temp_index,'anomaly_label'] != 'normal' else 'false positive'
-        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label'] if humi_temp_df.loc[min_temp_index,'anomaly_label'] != 'normal' else 'false positive'
-        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label'] if humi_temp_df.loc[max_humi_index,'anomaly_label'] != 'normal' else 'false positive'
-        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label'] if humi_temp_df.loc[min_humi_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label'] if humi_temp_df.loc[max_temp_index,'anomaly_label'] != 'normal' else 'false_positives'
+        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label'] if humi_temp_df.loc[min_temp_index,'anomaly_label'] != 'normal' else 'false_positives'
+        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label'] if humi_temp_df.loc[max_humi_index,'anomaly_label'] != 'normal' else 'false_positives'
+        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label'] if humi_temp_df.loc[min_humi_index,'anomaly_label'] != 'normal' else 'false_positives'
 
         min_max_anomaly_detector = MinMaxAnomalyDetector()
         evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, humi_temp_df, synthetic=True)
@@ -90,10 +90,10 @@ class TestEvaluators(unittest.TestCase):
         # The detector does not see the upward spike in humidity as anomalous because the max humidity
         # value is 70.
         # Evaluation_results:
-        # { 'normal':                                 temperature_anomaly   humidity_anomaly
-        #               1973-05-03 00:02:00+00:00     True                 False
-        #               1973-05-11 23:47:00+00:00     False                True
-        #               1973-05-13 12:02:00+00:00     True                 True,
+        # { 'false_positives':                                 temperature_anomaly   humidity_anomaly
+        #                        1973-05-03 00:02:00+00:00     True                  False
+        #                        1973-05-11 23:47:00+00:00     False                 True
+        #                        1973-05-13 12:02:00+00:00     True                  True,
         #
         # 'spike_uv':  False  
         # }
@@ -111,10 +111,10 @@ class TestEvaluators(unittest.TestCase):
         min_temp_index = step_humi_temp_df['temperature'].idxmin()
         max_humi_index = step_humi_temp_df['humidity'].idxmax()
         min_humi_index = step_humi_temp_df['humidity'].idxmin()
-        label_detected_anomalous_temp1 = step_humi_temp_df.loc[max_temp_index,'anomaly_label'] if step_humi_temp_df.loc[max_temp_index,'anomaly_label'] != 'normal' else 'false positive'
-        label_detected_anomalous_temp2 = step_humi_temp_df.loc[min_temp_index,'anomaly_label'] if step_humi_temp_df.loc[min_temp_index,'anomaly_label'] != 'normal' else 'false positive'
-        label_detected_anomalous_humi1 = step_humi_temp_df.loc[max_humi_index,'anomaly_label'] if step_humi_temp_df.loc[max_humi_index,'anomaly_label'] != 'normal' else 'false positive'
-        label_detected_anomalous_humi2 = step_humi_temp_df.loc[min_humi_index,'anomaly_label'] if step_humi_temp_df.loc[min_humi_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_temp1 = step_humi_temp_df.loc[max_temp_index,'anomaly_label'] if step_humi_temp_df.loc[max_temp_index,'anomaly_label'] != 'normal' else 'false_positives'
+        label_detected_anomalous_temp2 = step_humi_temp_df.loc[min_temp_index,'anomaly_label'] if step_humi_temp_df.loc[min_temp_index,'anomaly_label'] != 'normal' else 'false_positives'
+        label_detected_anomalous_humi1 = step_humi_temp_df.loc[max_humi_index,'anomaly_label'] if step_humi_temp_df.loc[max_humi_index,'anomaly_label'] != 'normal' else 'false_positives'
+        label_detected_anomalous_humi2 = step_humi_temp_df.loc[min_humi_index,'anomaly_label'] if step_humi_temp_df.loc[min_humi_index,'anomaly_label'] != 'normal' else 'false_positives'
 
         min_max_anomaly_detector = MinMaxAnomalyDetector()
         evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, step_humi_temp_df, synthetic=True)
@@ -124,11 +124,11 @@ class TestEvaluators(unittest.TestCase):
         self.assertIsInstance(evaluation_results[label_detected_anomalous_humi1],pd.DataFrame)
         self.assertIsInstance(evaluation_results[label_detected_anomalous_humi2],pd.DataFrame)
         # Evaluation results:
-        # { 'normal':                                 temperature_anomaly   humidity_anomaly
-        #               1973-05-03 00:02:00+00:00     True                 True
+        # { 'false_positives':                               temperature_anomaly  humidity_anomaly
+        #                      1973-05-03 00:02:00+00:00     True                 True
         #
-        # 'step_uv':                                  temperature_anomaly   humidity_anomaly
-        #               1973-05-26 12:02:00+00:00     True                  True
+        # 'step_uv':                                         temperature_anomaly   humidity_anomaly
+        #                      1973-05-26 12:02:00+00:00     True                  True
         # }
 
     def test_evaluate_anomaly_det_on_synth_not_anomalous_timeseries(self):
@@ -145,10 +145,10 @@ class TestEvaluators(unittest.TestCase):
         min_temp_index = humi_temp_df['temperature'].idxmin()
         max_humi_index = humi_temp_df['humidity'].idxmax()
         min_humi_index = humi_temp_df['humidity'].idxmin()
-        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label'] if humi_temp_df.loc[max_temp_index,'anomaly_label'] != 'normal' else 'false positive'
-        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label'] if humi_temp_df.loc[min_temp_index,'anomaly_label'] != 'normal' else 'false positive'
-        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label'] if humi_temp_df.loc[max_humi_index,'anomaly_label'] != 'normal' else 'false positive'
-        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label'] if humi_temp_df.loc[min_humi_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label'] if humi_temp_df.loc[max_temp_index,'anomaly_label'] != 'normal' else 'false_positives'
+        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label'] if humi_temp_df.loc[min_temp_index,'anomaly_label'] != 'normal' else 'false_positives'
+        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label'] if humi_temp_df.loc[max_humi_index,'anomaly_label'] != 'normal' else 'false_positives'
+        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label'] if humi_temp_df.loc[min_humi_index,'anomaly_label'] != 'normal' else 'false_positives'
 
         min_max_anomaly_detector = MinMaxAnomalyDetector()
         evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, humi_temp_df, synthetic=True)
@@ -158,8 +158,8 @@ class TestEvaluators(unittest.TestCase):
         self.assertIsInstance(evaluation_results[label_detected_anomalous_humi1],pd.DataFrame)
         self.assertIsInstance(evaluation_results[label_detected_anomalous_humi2],pd.DataFrame)
         # Evaluation results:
-        # { 'normal':                              temperature_anomaly  humidity_anomaly
-        #            1973-05-03 00:02:00+00:00     True                 True
-        #            1973-05-03 12:02:00+00:00     True                 True
+        # { 'false_positives':                              temperature_anomaly  humidity_anomaly
+        #                     1973-05-03 00:02:00+00:00     True                 True
+        #                     1973-05-03 12:02:00+00:00     True                 True
         # }
 

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -1,8 +1,11 @@
 from ..evaluators import evaluate_anomaly_detector
 from ..anomaly_detectors import MinMaxAnomalyDetector
+from ..synthetic_data import SyntheticHumiTempTimeseriesGenerator
 from ..utils import generate_timeseries_df
 import unittest
 import pandas as pd
+import random as rnd
+import numpy as np
 
 
 # Setup logging
@@ -10,6 +13,11 @@ from .. import logger
 logger.setup()
 
 class TestEvaluators(unittest.TestCase):
+
+    def setUp(self):
+
+        rnd.seed(123)
+        np.random.seed(123)
 
     def test_evaluate_anomaly_detector(self):
 
@@ -43,9 +51,34 @@ class TestEvaluators(unittest.TestCase):
         self.assertEqual(evaluation_results['anomaly_1'].loc['2025-06-10 14:00:00+00:00','value_anomaly'],True)
         self.assertEqual(evaluation_results['normal'].loc['2025-06-10 15:00:00+00:00','value_anomaly'],False)
 
+    def test_evaluate_anomaly_det_on_spiked_synth_timeseries(self):
 
+        spiked_humi_temp_generator = SyntheticHumiTempTimeseriesGenerator()
+        spiked_humi_temp_df = spiked_humi_temp_generator.generate(anomalies=['spike_uv'],effects=[])
+        # Generated DataFrame:
+        # Timestamp                    temperature           humidity             anomaly_label    effect_label
+        # ...
+        # 1973-05-07 11:02:00+00:00    24.761107302835810    50.63704719243785    normal           bare
+        # 1973-05-07 11:17:00+00:00    24.868377982941322    50.350992045489804   normal           bare
+        # 1973-05-07 11:32:00+00:00    24.944096137309916    50.14907696717356    normal           bare
+        # 1973-05-07 11:47:00+00:00    15.987937529180115    59.03216658885302    spike_uv         bare
+        # 1973-05-07 12:02:00+00:00    24.999714422981285    50.000761538716574   normal           bare
+        # 1973-05-07 12:17:00+00:00    24.979376388246145    50.05499629801029    normal           bare
+        # 1973-05-07 12:32:00+00:00    24.927010515561776    50.194638625168594   normal           bare
+        # ...
+        min_max_anomaly_detector = MinMaxAnomalyDetector()
+        evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, spiked_humi_temp_df, synthetic=True)
+        self.assertEqual(len(evaluation_results),2)
+        self.assertIsInstance(evaluation_results,dict)
+        self.assertIsInstance(evaluation_results['spike_uv'],pd.DataFrame)
+        # The detector does not see the downward spike in temperature as anomalous because the min temperature
+        # value is 17.5.
+        # The detector does not see the upward spike in humidity as anomalous because the max humidity
+        # value is 70.
+        # Evaluation_results:
+        # { 'normal':         temperature_anomaly   humidity_anomaly
+        #               0     False                 False,
+        # 'spike_uv':         temperature_anomaly   humidity_anomaly
+        #               474   False                  False
+        # }
 
-
-
-
-  

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -1,0 +1,48 @@
+from ..evaluators import evaluate_anomaly_detector
+from ..anomaly_detectors import MinMaxAnomalyDetector
+from ..utils import generate_timeseries_df
+import unittest
+import pandas as pd
+
+
+# Setup logging
+from .. import logger
+logger.setup()
+
+class TestEvaluators(unittest.TestCase):
+
+    def test_evaluate_anomaly_detector(self):
+
+        min_max_anomaly_detector = MinMaxAnomalyDetector()
+        timeseries_df = generate_timeseries_df(entries=4, variables=1)
+        timeseries_df['anomaly_label'] = ['anomaly_1','normal','anomaly_2','normal']
+        # Generated DataFrame:
+        #                             value                  anomaly_label
+        # timestamp
+        # 2025-06-10 14:00:00+00:00   0.0                    anomaly_1
+        # 2025-06-10 15:00:00+00:00   0.8414709848078965     normal
+        # 2025-06-10 16:00:00+00:00   0.9092974268256817     anomaly_2
+        # 2025-06-10 17:00:00+00:00   0.1411200080598672     normal
+        
+        evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, timeseries_df)
+        # Evaluation_results
+        #{ 'normal':     value_anomaly    False
+        #                Name: 2025-06-10 15:00:00+00:00, dtype: bool,
+        #  'anomaly_1':  value_anomaly    True
+        #                Name: 2025-06-10 14:00:00+00:00, dtype: bool,
+        # 'anomaly_2':   value_anomaly    True
+        #                Name: 2025-06-10 16:00:00+00:00, dtype: bool}
+
+        self.assertIsInstance(evaluation_results,dict)
+        self.assertEqual(len(evaluation_results),3)
+        self.assertIsInstance(evaluation_results['anomaly_1'],pd.Series)
+        self.assertEqual(evaluation_results['anomaly_2'].loc['value_anomaly'],True)
+        self.assertEqual(evaluation_results['anomaly_1'].loc['value_anomaly'],True)
+        self.assertEqual(evaluation_results['normal'].loc['value_anomaly'],False)
+
+
+
+
+
+
+  

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -48,10 +48,10 @@ class TestEvaluators(unittest.TestCase):
         self.assertEqual(len(evaluation_results),3)
         self.assertIsInstance(evaluation_results['anomaly_1'],pd.DataFrame)
         self.assertIsInstance(evaluation_results['anomaly_2'],pd.DataFrame)
-        self.assertIsInstance(evaluation_results['normal'],bool)
+        self.assertIsInstance(evaluation_results['false positive'],bool)
         self.assertEqual(evaluation_results['anomaly_2'].loc['2025-06-10 16:00:00+00:00','value_anomaly'],True)
         self.assertEqual(evaluation_results['anomaly_1'].loc['2025-06-10 14:00:00+00:00','value_anomaly'],True)
-        self.assertEqual(evaluation_results['normal'],False)
+        self.assertEqual(evaluation_results['false positive'],False)
 
     def test_evaluate_anomaly_det_on_spiked_synth_timeseries(self):
 
@@ -72,10 +72,10 @@ class TestEvaluators(unittest.TestCase):
         min_temp_index = humi_temp_df['temperature'].idxmin()
         max_humi_index = humi_temp_df['humidity'].idxmax()
         min_humi_index = humi_temp_df['humidity'].idxmin()
-        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label']
-        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label']
-        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label']
-        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label']
+        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label'] if humi_temp_df.loc[max_temp_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label'] if humi_temp_df.loc[min_temp_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label'] if humi_temp_df.loc[max_humi_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label'] if humi_temp_df.loc[min_humi_index,'anomaly_label'] != 'normal' else 'false positive'
 
         min_max_anomaly_detector = MinMaxAnomalyDetector()
         evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, humi_temp_df, synthetic=True)
@@ -111,10 +111,10 @@ class TestEvaluators(unittest.TestCase):
         min_temp_index = step_humi_temp_df['temperature'].idxmin()
         max_humi_index = step_humi_temp_df['humidity'].idxmax()
         min_humi_index = step_humi_temp_df['humidity'].idxmin()
-        label_detected_anomalous_temp1 = step_humi_temp_df.loc[max_temp_index,'anomaly_label']
-        label_detected_anomalous_temp2 = step_humi_temp_df.loc[min_temp_index,'anomaly_label']
-        label_detected_anomalous_humi1 = step_humi_temp_df.loc[max_humi_index,'anomaly_label']
-        label_detected_anomalous_humi2 = step_humi_temp_df.loc[min_humi_index,'anomaly_label']
+        label_detected_anomalous_temp1 = step_humi_temp_df.loc[max_temp_index,'anomaly_label'] if step_humi_temp_df.loc[max_temp_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_temp2 = step_humi_temp_df.loc[min_temp_index,'anomaly_label'] if step_humi_temp_df.loc[min_temp_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_humi1 = step_humi_temp_df.loc[max_humi_index,'anomaly_label'] if step_humi_temp_df.loc[max_humi_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_humi2 = step_humi_temp_df.loc[min_humi_index,'anomaly_label'] if step_humi_temp_df.loc[min_humi_index,'anomaly_label'] != 'normal' else 'false positive'
 
         min_max_anomaly_detector = MinMaxAnomalyDetector()
         evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, step_humi_temp_df, synthetic=True)
@@ -145,10 +145,10 @@ class TestEvaluators(unittest.TestCase):
         min_temp_index = humi_temp_df['temperature'].idxmin()
         max_humi_index = humi_temp_df['humidity'].idxmax()
         min_humi_index = humi_temp_df['humidity'].idxmin()
-        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label']
-        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label']
-        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label']
-        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label']
+        label_detected_anomalous_temp1 = humi_temp_df.loc[max_temp_index,'anomaly_label'] if humi_temp_df.loc[max_temp_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_temp2 = humi_temp_df.loc[min_temp_index,'anomaly_label'] if humi_temp_df.loc[min_temp_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_humi1 = humi_temp_df.loc[max_humi_index,'anomaly_label'] if humi_temp_df.loc[max_humi_index,'anomaly_label'] != 'normal' else 'false positive'
+        label_detected_anomalous_humi2 = humi_temp_df.loc[min_humi_index,'anomaly_label'] if humi_temp_df.loc[min_humi_index,'anomaly_label'] != 'normal' else 'false positive'
 
         min_max_anomaly_detector = MinMaxAnomalyDetector()
         evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, humi_temp_df, synthetic=True)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -72,7 +72,7 @@ class TestEvaluators(unittest.TestCase):
         self.assertIsInstance(evaluation_results,dict)
         self.assertIsInstance(evaluation_results['spike_uv'],pd.DataFrame)
         # The detector does not see the downward spike in temperature as anomalous because the min temperature
-        # value is 17.5.
+        # value is 10.
         # The detector does not see the upward spike in humidity as anomalous because the max humidity
         # value is 70.
         # Evaluation_results:
@@ -81,4 +81,19 @@ class TestEvaluators(unittest.TestCase):
         # 'spike_uv':         temperature_anomaly   humidity_anomaly
         #               474   False                  False
         # }
+
+    def test_evaluate_anomaly_det_on_step_synth_timeseries(self):
+
+        step_humi_temp_generator = SyntheticHumiTempTimeseriesGenerator()
+        step_humi_temp_df = step_humi_temp_generator.generate(anomalies=['step_uv'],effects=[])
+        # Generated DataFrame:
+        # Timestamp                    temperature           humidity             anomaly_label    effect_label
+        # ...
+        # 1973-05-25 13:32:00+00:00   34.4037864008933       41.58990293095119    step_uv          bare
+        # ...
+        min_max_anomaly_detector = MinMaxAnomalyDetector()
+        evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, step_humi_temp_df, synthetic=True)
+        self.assertEqual(len(evaluation_results),2)
+        self.assertIsInstance(evaluation_results,dict)
+        self.assertIsInstance(evaluation_results['step_uv'],pd.DataFrame)
 

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -26,19 +26,22 @@ class TestEvaluators(unittest.TestCase):
         
         evaluation_results = evaluate_anomaly_detector(min_max_anomaly_detector, timeseries_df)
         # Evaluation_results
-        #{ 'normal':     value_anomaly    False
-        #                Name: 2025-06-10 15:00:00+00:00, dtype: bool,
-        #  'anomaly_1':  value_anomaly    True
-        #                Name: 2025-06-10 14:00:00+00:00, dtype: bool,
-        # 'anomaly_2':   value_anomaly    True
-        #                Name: 2025-06-10 16:00:00+00:00, dtype: bool}
+        #{'normal':      timestamp                   value_anomaly
+        #                2025-06-10 15:00:00+00:00   False,
+        #
+        #                timestamp                   value_anomaly
+        # 'anomaly_1':   2025-06-10 15:00:00+00:00   True,
+        #
+        #                timestamp                   value_anomaly
+        # 'anomaly_2':   2025-06-10 14:00:00+00:00   True
+        #}
 
         self.assertIsInstance(evaluation_results,dict)
         self.assertEqual(len(evaluation_results),3)
-        self.assertIsInstance(evaluation_results['anomaly_1'],pd.Series)
-        self.assertEqual(evaluation_results['anomaly_2'].loc['value_anomaly'],True)
-        self.assertEqual(evaluation_results['anomaly_1'].loc['value_anomaly'],True)
-        self.assertEqual(evaluation_results['normal'].loc['value_anomaly'],False)
+        self.assertIsInstance(evaluation_results['anomaly_1'],pd.DataFrame)
+        self.assertEqual(evaluation_results['anomaly_2'].loc['2025-06-10 16:00:00+00:00','value_anomaly'],True)
+        self.assertEqual(evaluation_results['anomaly_1'].loc['2025-06-10 14:00:00+00:00','value_anomaly'],True)
+        self.assertEqual(evaluation_results['normal'].loc['2025-06-10 15:00:00+00:00','value_anomaly'],False)
 
 
 


### PR DESCRIPTION
#8 
The module "evaluators.py" contains the function "evaluate_anomaly_detector()" with 3 input arguments:
- an instance of the class "AnomalyDetector";
- a timeseries in the form of a pandas DataFrame;
-  a switch "synthetic" that tells if the input timeseries is synthetic or not. 
The timeseries needs to have a column "anomaly_label" in order to do the evaluation and for the moment only the "MinMaxAnomalyDetector" is supported. 
If the timeseries is synthetic (synthetic = True), these operations need to be performed before applying the anomaly detector instance:
- using the timestamps in the column "time" as indexes
- delating the column "time" and "effect_label" (inlace)
The column "anomaly_label" is stored and than delated from the timeseries (inplace)
At this point, the anomaly detector instance  is applied to the timeseries.
The evaluation is done searching for the rows of the data frame both marked and detected as anomalous.
The return type of the function is a dict with the anomaly labels of the timeseries as keys. If the anomaly has been detected, in correspondence of its key there is a data frame with the rows target as anomalous by the detector. If the anomaly has not been detected, in correspondence of its keys there is "False" (bool). 
Because also not anomalous data points are labelled (for the moment 'anomaly_label' = 'normal'), their label is a key of the returned dict and in this way false positive can be taken into account.
The module "test_evaluators.py" tests the function using a non synthetic timeseries and 3 synthetic timeseries, one with univariate spike anomaly, one with univariate step anomaly and one without anomalies.