### PR TITLE
Feature: evaluation granularity

### DIFF
--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -102,11 +102,11 @@ class Evaluator():
             flagged_dataset = _get_model_output(dataset_copies[j],model)
             for i,sample_df in enumerate(flagged_dataset):
                 if granularity == 'data_point':
-                    single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels)
+                    single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels_list[i])
                 if granularity == 'variable':
-                    single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels)
+                    single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels_list[i])
                 if granularity == 'series':
-                    single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels)
+                    single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i])
                 
             models_scores[model_name] = _calculate_model_scores(single_model_evaluation,granularity=granularity)
             j+=1

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -101,7 +101,13 @@ class Evaluator():
             single_model_evaluation = {}
             flagged_dataset = _get_model_output(dataset_copies[j],model)
             for i,sample_df in enumerate(flagged_dataset):
-                single_model_evaluation[f'sample_{i+1}'] = evaluate_anomaly_detector(sample_df,anomaly_labels_list[i])
+                if granularity == 'data_point':
+                    single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels)
+                if granularity == 'variable':
+                    single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels)
+                if granularity == 'series':
+                    single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels)
+                
             models_scores[model_name] = _calculate_model_scores(single_model_evaluation,granularity=granularity)
             j+=1
 

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -46,7 +46,7 @@ def evaluate_anomaly_detector(evaluated_timeseries_df, anomaly_labels, details=F
         return evaluation_results
 
 
-def _calculate_model_scores(single_model_evaluation={}):
+def _calculate_model_scores(single_model_evaluation={},granularity='data_point'):
     anomalies = list(single_model_evaluation['sample_1'].keys())
     samples_n = len(single_model_evaluation)
     detections_per_anomaly = {}
@@ -80,7 +80,7 @@ class Evaluator():
             dataset_copies.append(dataset_copy)
         return dataset_copies
 
-    def evaluate(self,models={}):
+    def evaluate(self,models={},granularity='data_point'):
         if not models:
             raise ValueError('There are no models to evaluate')
         if not self.test_data:
@@ -102,7 +102,7 @@ class Evaluator():
             flagged_dataset = _get_model_output(dataset_copies[j],model)
             for i,sample_df in enumerate(flagged_dataset):
                 single_model_evaluation[f'sample_{i+1}'] = evaluate_anomaly_detector(sample_df,anomaly_labels_list[i])
-            models_scores[model_name] = _calculate_model_scores(single_model_evaluation)
+            models_scores[model_name] = _calculate_model_scores(single_model_evaluation,granularity=granularity)
             j+=1
 
         return models_scores

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -142,3 +142,20 @@ def _variable_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
 
     one_series_evaluation_result['false_positives'] = one_series_evaluation_result.pop(None)
     return one_series_evaluation_result
+
+def _point_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
+    one_series_evaluation_result = {}
+    normalization_factor = len(flagged_timeseries_df)
+
+    for anomaly,frequency in anomaly_labels_df.value_counts(dropna=False).items():
+        anomaly_count = 0
+        for timestamp in flagged_timeseries_df.index:
+            if anomaly_labels_df[timestamp] == anomaly:
+                for column in flagged_timeseries_df.filter(like='anomaly').columns:
+                    if flagged_timeseries_df.loc[timestamp,column]:
+                        anomaly_count += 1
+                        break
+        one_series_evaluation_result[anomaly] = anomaly_count / normalization_factor
+
+    one_series_evaluation_result['false_positives'] = one_series_evaluation_result.pop(None)
+    return one_series_evaluation_result

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -159,3 +159,26 @@ def _point_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
 
     one_series_evaluation_result['false_positives'] = one_series_evaluation_result.pop(None)
     return one_series_evaluation_result
+
+def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
+    anomalies = []
+    for anomaly,frequency in anomaly_labels_df.value_counts(dropna=False).items():
+        if anomaly is not None:
+            anomalies.append(anomaly)
+    anomalies_n = len(anomalies)
+    if anomalies_n > 1:
+        raise ValueError('Evaluation with series granularity supports series with only one anomaly')
+
+    one_series_evaluation_result = {}
+    is_series_anomalous = 0
+    for timestamp in flagged_timeseries_df.index:
+        for column in flagged_timeseries_df.filter(like='anomaly').columns:
+            if flagged_timeseries_df.loc[timestamp,column]:
+                is_series_anomalous = 1
+                break
+    if is_series_anomalous and not anomalies:
+        one_series_evaluation_result['false_positives'] = 1
+    elif is_series_anomalous and anomalies:
+        one_series_evaluation_result[anomalies[0]] = 1
+
+    return one_series_evaluation_result

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -55,6 +55,8 @@ def _calculate_model_scores(single_model_evaluation={},granularity='data_point')
     anomaly_scores = {}
     for anomaly in dataset_anomalies:
         anomaly_scores[anomaly] = 0
+    if 'false_positives' not in dataset_anomalies:
+        anomaly_scores['false_positives'] = 0.0
 
     for anomaly in dataset_anomalies:
         for sample in single_model_evaluation.keys():
@@ -186,5 +188,7 @@ def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
         one_series_evaluation_result['false_positives'] = 1
     elif is_series_anomalous and anomalies:
         one_series_evaluation_result[anomalies[0]] = 1
+    elif not is_series_anomalous and anomalies:
+        one_series_evaluation_result[anomalies[0]] = 0
 
     return one_series_evaluation_result

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -298,11 +298,13 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(model_scores['anomaly_2'],0.3333333333333333)
         self.assertAlmostEqual(model_scores['false_positives'],0.333333333333333)
 
-    def test_evaluate(self):
-        anomalies = ['spike_uv','step_uv']
+    def test_evaluate_point_granularity(self):
+        anomalies = ['step_uv']
+        effects = []
+        # series with 2880 data points
         series_generator = HumiTempTimeseriesGenerator()
-        series1 = series_generator.generate(anomalies=anomalies)
-        series2 = series_generator.generate(anomalies=anomalies)
+        series1 = series_generator.generate(anomalies=anomalies,effects=effects)
+        series2 = series_generator.generate(anomalies=anomalies,effects=effects)
         dataset = [series1,series2]
         evaluator = Evaluator(test_data=dataset)
         minmax1 = MinMaxAnomalyDetector()
@@ -312,17 +314,18 @@ class TestEvaluators(unittest.TestCase):
                 'detector_2': minmax2,
                 'detector_3': minmax3
                 }
-        evaluation_results = evaluator.evaluate(models=models)
+        evaluation_results = evaluator.evaluate(models=models,granularity='data_point')
         # Evaluation_results:
-        # detector_1: {'step_uv': 1.0, 'spike_uv': 0.0, 'false_positives': 4}
-        # detector_2: {'step_uv': 1.0, 'spike_uv': 0.0, 'false_positives': 4}
-        # detector_3: {'step_uv': 1.0, 'spike_uv': 0.0, 'false_positives': 4}
-
+        # detector_1: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
+        # detector_2: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
+        # detector_3: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
         self.assertIsInstance(evaluation_results,dict)
         self.assertEqual(len(evaluation_results),3)
-        self.assertEqual(len(evaluation_results['detector_1']),3)
-        self.assertEqual(len(evaluation_results['detector_2']),3)
-        self.assertEqual(len(evaluation_results['detector_3']),3)
+        self.assertEqual(len(evaluation_results['detector_1']),2)
+        self.assertEqual(len(evaluation_results['detector_2']),2)
+        self.assertEqual(len(evaluation_results['detector_3']),2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['step_uv'],0.000694444444444444)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives'],0.000694444444444444)
 
     def test_copy_dataset(self):
         series_generator = HumiTempTimeseriesGenerator()

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -7,6 +7,7 @@ from ..evaluators import _format_for_anomaly_detector
 from ..evaluators import _calculate_model_scores
 from ..evaluators import Evaluator
 from ..evaluators import _variable_granularity_evaluation
+from ..evaluators import _point_granularity_evaluation
 import unittest
 import pandas as pd
 import random as rnd
@@ -316,3 +317,18 @@ class TestEvaluators(unittest.TestCase):
         self.assertEqual(len(evaluation_result),2)
         self.assertAlmostEqual(evaluation_result['step_uv'],1/len(series))
         self.assertAlmostEqual(evaluation_result['false_positives'],1/len(series))
+
+    def test_point_granularity_evaluation(self):
+        series_generator = HumiTempTimeseriesGenerator()
+        series = series_generator.generate(anomalies=['step_uv'])
+        minmax = MinMaxAnomalyDetector()
+        formatted_series,anomaly_labels = _format_for_anomaly_detector(series,synthetic=True)
+        flagged_series = minmax.apply(formatted_series)
+        evaluation_result = _point_granularity_evaluation(flagged_series,anomaly_labels)
+        # evaluation_result:
+        # { 'step_uv': 0.0006944444444444445
+        # 'false_positives': 0.0006944444444444445
+        # }
+        self.assertEqual(len(evaluation_result),2)
+        self.assertAlmostEqual(evaluation_result['step_uv'],2/len(series))
+        self.assertAlmostEqual(evaluation_result['false_positives'],2/len(series))

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -327,6 +327,36 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['step_uv'],0.000694444444444444)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives'],0.000694444444444444)
 
+    def test_evaluate_variable_granularity(self):
+        anomalies = ['step_uv']
+        effects = []
+        # series with 2880 data points
+        series_generator = HumiTempTimeseriesGenerator()
+        series1 = series_generator.generate(anomalies=anomalies,effects=effects)
+        series2 = series_generator.generate(anomalies=anomalies,effects=effects)
+        dataset = [series1,series2]
+        evaluator = Evaluator(test_data=dataset)
+        minmax1 = MinMaxAnomalyDetector()
+        minmax2 = MinMaxAnomalyDetector()
+        minmax3 = MinMaxAnomalyDetector()
+        models={'detector_1': minmax1,
+                'detector_2': minmax2,
+                'detector_3': minmax3
+                }
+        evaluation_results = evaluator.evaluate(models=models,granularity='variable')
+        # Evaluation_results:
+        # detector_1: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
+        # detector_2: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
+        # detector_3: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
+
+        self.assertIsInstance(evaluation_results,dict)
+        self.assertEqual(len(evaluation_results),3)
+        self.assertEqual(len(evaluation_results['detector_1']),2)
+        self.assertEqual(len(evaluation_results['detector_2']),2)
+        self.assertEqual(len(evaluation_results['detector_3']),2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['step_uv'],0.000694444444444444)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives'],0.000694444444444444)
+
     def test_copy_dataset(self):
         series_generator = HumiTempTimeseriesGenerator()
         series1 = series_generator.generate(effects=['noise'])

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -388,6 +388,36 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['step_uv'],0.5)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives'],0.5)
 
+    def test_series_granularity_eval_with_non_detected_anomalies(self):
+        effects = []
+        series_generator = HumiTempTimeseriesGenerator()
+        # series1 will be a true anomaly for the minmax
+        series1 = series_generator.generate(anomalies=['step_uv'],effects=effects)
+        # series2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
+        series2 = series_generator.generate(anomalies=['pattern_uv'],effects=effects)
+        dataset = [series1,series2]
+        evaluator = Evaluator(test_data=dataset)
+        minmax1 = MinMaxAnomalyDetector()
+        minmax2 = MinMaxAnomalyDetector()
+        minmax3 = MinMaxAnomalyDetector()
+        models={'detector_1': minmax1,
+                'detector_2': minmax2,
+                'detector_3': minmax3
+                }
+        evaluation_results = evaluator.evaluate(models=models,granularity='series')
+        # Evaluation_results:
+        # detector_1: {'step_uv': 0.5, 'pattern_uv': 0.5, 'false_positives': 0.0}
+        # detector_2: {'step_uv': 0.5, 'pattern_uv': 0.5, 'false_positives': 0.0}
+        # detector_3: {'step_uv': 0.5, 'pattern_uv': 0.5, 'false_positives': 0.0}
+        self.assertIsInstance(evaluation_results,dict)
+        self.assertEqual(len(evaluation_results),3)
+        self.assertEqual(len(evaluation_results['detector_1']),3)
+        self.assertEqual(len(evaluation_results['detector_2']),3)
+        self.assertEqual(len(evaluation_results['detector_3']),3)
+        self.assertAlmostEqual(evaluation_results['detector_1']['step_uv'],0.5)
+        self.assertAlmostEqual(evaluation_results['detector_1']['pattern_uv'],0.5)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives'],0.0)
+
     def test_raised_error_evaluation_series_granularity(self):
         anomalies = ['step_uv','spike_uv']
         series_generator = HumiTempTimeseriesGenerator()

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -6,6 +6,7 @@ from ..evaluators import _get_model_output
 from ..evaluators import _format_for_anomaly_detector
 from ..evaluators import _calculate_model_scores
 from ..evaluators import Evaluator
+from ..evaluators import _variable_granularity_evaluation
 import unittest
 import pandas as pd
 import random as rnd
@@ -300,3 +301,18 @@ class TestEvaluators(unittest.TestCase):
         self.assertEqual(len(dataset_copies[0]),2)
         self.assertIsInstance(dataset_copies[1],list)
         self.assertEqual(len(dataset_copies[1]),2)
+
+    def test_variable_granularity_evaluation(self):
+        series_generator = HumiTempTimeseriesGenerator()
+        series = series_generator.generate(anomalies=['step_uv'])
+        minmax = MinMaxAnomalyDetector()
+        formatted_series,anomaly_labels = _format_for_anomaly_detector(series,synthetic=True)
+        flagged_series = minmax.apply(formatted_series)
+        evaluation_result = _variable_granularity_evaluation(flagged_series,anomaly_labels)
+        # evaluation_result:
+        # { 'step_uv': 0.00034722222222222224
+        # 'false_positives': 0.00034722222222222224
+        # }
+        self.assertEqual(len(evaluation_result),2)
+        self.assertAlmostEqual(evaluation_result['step_uv'],1/len(series))
+        self.assertAlmostEqual(evaluation_result['false_positives'],1/len(series))

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -242,25 +242,61 @@ class TestEvaluators(unittest.TestCase):
     def test_calculate_model_scores(self):
         single_model_evaluation = {
             'sample_1': {
-                'anomaly_1': True,
-                'anomaly_2': False,
-                'false_positives': 2
+                'anomaly_1': 0.5,
+                'anomaly_2': 0.2,
+                'false_positives': 0.6
             },
             'sample_2': {
-                'anomaly_1': True,
-                'anomaly_2': True,
-                'false_positives': 1
+                'anomaly_1': 0.3,
+                'anomaly_2': 0.4,
+                'anomaly_3': 0.1,
+                'false_positives': 0.2
             },
             }
-        model_scores = _calculate_model_scores(single_model_evaluation)
+        model_scores = _calculate_model_scores(single_model_evaluation,granularity='data_point')
+        # model_scores:
+        # { 'anomaly_3': 0.1,
+        #   'anomaly_1': 0.8,
+        #   'false_positives': 0.8,
+        #   'anomaly_2': 0.6
+        # }
+        self.assertEqual(len(model_scores),4)
+        self.assertIsInstance(model_scores,dict)
+        self.assertIn('anomaly_1',model_scores.keys())
+        self.assertIn('anomaly_2',model_scores.keys())
+        self.assertIn('anomaly_3',model_scores.keys())
+        self.assertIn('false_positives',model_scores.keys())
+        self.assertAlmostEqual(model_scores['anomaly_1'],0.8)
+        self.assertAlmostEqual(model_scores['anomaly_2'],0.6)
+        self.assertAlmostEqual(model_scores['anomaly_3'],0.1)
+        self.assertAlmostEqual(model_scores['false_positives'],0.8)
+
+    def test_calculate_model_score_series_granularity(self):
+        single_model_evaluation = {
+            'sample_1': {
+                'anomaly_1': 1,
+            },
+            'sample_2': {
+                'false_positives': 1
+            },
+            'sample_3': {
+                'anomaly_2': 1
+            }
+            }
+        model_scores = _calculate_model_scores(single_model_evaluation,granularity='series')
+        # model_scores:
+        # { 'anomaly_1': 0.3333333333333333,
+        #   'false_positives': 0.3333333333333333,
+        #   'anomaly_2': 0.3333333333333333
+        # }
         self.assertEqual(len(model_scores),3)
         self.assertIsInstance(model_scores,dict)
         self.assertIn('anomaly_1',model_scores.keys())
         self.assertIn('anomaly_2',model_scores.keys())
         self.assertIn('false_positives',model_scores.keys())
-        self.assertAlmostEqual(model_scores['anomaly_1'],1.0)
-        self.assertAlmostEqual(model_scores['anomaly_2'],0.5)
-        self.assertAlmostEqual(model_scores['false_positives'],3)
+        self.assertAlmostEqual(model_scores['anomaly_1'],0.3333333333333333)
+        self.assertAlmostEqual(model_scores['anomaly_2'],0.3333333333333333)
+        self.assertAlmostEqual(model_scores['false_positives'],0.333333333333333)
 
     def test_evaluate(self):
         anomalies = ['spike_uv','step_uv']


### PR DESCRIPTION
Now it is possible to choose the granularity of the evaluation setting the parameter `granularity` in the function `evaluate()`. There are 3 possible choices:
1) `granularity = 'variable'`: the detected anomalies of a specific type are counted for each variable of the series (same for false positives). For each series of the dataset, the counts are then divided for a normalization factor, given by the product of the number of variables in the series by its length. 
Suppose you have series of 2880 data points and 2 variables (temperature and humidity) like this:

| Timestamp                  | Temperature          | Humidity             | Anomaly Label |
|---------------------------|----------------------|-----------------------|----------------|
| 1973-05-07 11:02:00+00:00 | 24.761107302835810   | 50.63704719243785    | 'spike_uv'     |
| 1973-05-07 11:17:00+00:00 | 24.868377982941322   | 50.350992045489804   | None           |
| 1973-05-07 11:32:00+00:00 | 24.944096137309916   | 50.14907696717356    | None           |
| ...                       | ...                  | ...                   | ...            |
| 1973-05-07 11:47:00+00:00 | 15.987937529180115   | 59.03216658885302    | 'step_uv'      |
| 1973-05-07 12:02:00+00:00 | 24.999714422981285   | 50.000761538716574   | 'step_uv'      |
| 1973-05-07 12:17:00+00:00 | 24.979376388246145   | 50.05499629801029    | 'step_uv'      |
| 1973-05-07 12:32:00+00:00 | 24.927010515561776   | 50.194638625168594   | 'spike_uv'     |
| ...                       | ...                  | ...                   | ...            |


there are  5 anomalies, 2 of type 'spike_uv' for the temperature and 3 of type 'step_uv' for the humidity. The model sees both the anomalies on the temperature but only 1 anomaly on the humidity and gives 2 false positives, one on temperature and one on humidity at the same timestamp. 

| Timestamp                  | Anomaly Label | Temperature Anomaly | Humidity Anomaly |
|---------------------------|---------------|----------------------|------------------|
| 1973-05-07 11:02:00+00:00 | 'spike_uv'    | 1                    | 0                |
| 1973-05-07 11:17:00+00:00 | None          | 1                    | 0                |
| 1973-05-07 11:32:00+00:00 | None          | 0                    | 1                |
| ...                       | ...           | ...                  | ...              |
| 1973-05-07 11:47:00+00:00 | 'step_uv'     | 0                    | 1                |
| 1973-05-07 12:02:00+00:00 | 'step_uv'     | 0                    | 0                |
| 1973-05-07 12:17:00+00:00 | 'step_uv'     | 0                    | 0                |
| 1973-05-07 12:32:00+00:00 | 'spike_uv'    | 1                    | 0                |
| ...                       | ...           | ...                  | ...              |

The evaluation of the model on this series will be the following dictionary:  
```
series_evaluation = { 'spike_uv': 0.000347,  'step_uv': 0.00017, 'false_positives': 0.000347}
```
Of course, this granularity can be used on models that assign anomaly flags to each variable of the series
2) `granularity = 'data_point'`: the detected anomalies of a specific type are counted for each data point of the series. In this case the normalization factor is only the length of the series. For the same example as before, the evaluation result on the series with point granularity will be:
```
series_evaluation = { 'spike_uv': 0.000694,  'step_uv': 0.000347,  'false_positives': 0.000694}
```
The "series_evaluation" dictionary is created for each series of the dataset. To obtain the evaluation on the dataset, values corresponding to the same key are summed. 
This is done for each model. 
3) `granularity=series`:  having only one type of anomaly per series is necessary to use this granularity. The anomalous series of the dataset  detected as anomalous raise the counts of the type of anomaly. Not anomalous series detected as anomalous raise the counts of false positives. 
Suppose we have a dataset with 3 normal series and 4 anomalous series with spike_uv, step_uv, pattern_uv and clouds anomalies. The model detects spike_uv and clouds anomalies and gives 1 false positives. The result of the evaluation is:
```
evaluation: { 'spike_uv': 0.143, 'clouds': 0.143, 'step_uv': 0.000, 'fase_positives': 0.143
}
```
Values are normalized to the number of series inside the dataset 