### PR TITLE
Fix: bug evaluator

### DIFF
--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -9,8 +9,8 @@ def _format_for_anomaly_detector(input_df,synthetic=False):
         raise ValueError('The input DataFrame has to contain an "anomaly_label" column for evaluation')
 
     anomaly_labels = input_df.loc[:,'anomaly_label']
-    input_df.drop(columns=['anomaly_label'],inplace=True)
-    return input_df,anomaly_labels
+    output_df = input_df.drop(columns=['anomaly_label'],inplace=False)
+    return output_df,anomaly_labels
 
 def evaluate_anomaly_detector(evaluated_timeseries_df, anomaly_labels, details=False):
 

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -2,15 +2,15 @@ from .anomaly_detectors.naive import MinMaxAnomalyDetector
 import pandas as pd
 from copy import deepcopy
 
-def _format_for_anomaly_detector(input_df,synthetic=False):
+def _format_for_anomaly_detector(df,synthetic=False):
     if synthetic:
-        input_df.drop(columns=['effect_label'],inplace=True)
-    if 'anomaly_label' not in input_df.columns:
+        df = df.drop(columns=['effect_label'],inplace=False)
+    if 'anomaly_label' not in df.columns:
         raise ValueError('The input DataFrame has to contain an "anomaly_label" column for evaluation')
 
-    anomaly_labels = input_df.loc[:,'anomaly_label']
-    output_df = input_df.drop(columns=['anomaly_label'],inplace=False)
-    return output_df,anomaly_labels
+    anomaly_labels = df.loc[:,'anomaly_label']
+    df = df.drop(columns=['anomaly_label'],inplace=False)
+    return df,anomaly_labels
 
 def evaluate_anomaly_detector(evaluated_timeseries_df, anomaly_labels, details=False):
 

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -507,3 +507,23 @@ class TestEvaluators(unittest.TestCase):
             evaluation_result2 = _series_granularity_evaluation(flagged_series2,anomaly_labels2)
         except Exception as e:
             self.assertIsInstance(e,ValueError)
+
+    def test_double_evaluator(self):
+        anomalies = ['step_uv']
+        effects = []
+        series_generator = HumiTempTimeseriesGenerator()
+        # series1 will be a true anomaly for the minmax
+        series1 = series_generator.generate(anomalies=anomalies,effects=effects)
+        # series2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
+        series2 = series_generator.generate(anomalies=[],effects=effects)
+        dataset = [series1,series2]
+        evaluator = Evaluator(test_data=dataset)
+        minmax1 = MinMaxAnomalyDetector()
+        minmax2 = MinMaxAnomalyDetector()
+        minmax3 = MinMaxAnomalyDetector()
+        models={'detector_1': minmax1,
+                'detector_2': minmax2,
+                'detector_3': minmax3
+                }
+        evaluation_results = evaluator.evaluate(models=models,granularity='series')
+        evaluation_results = evaluator.evaluate(models=models,granularity='series')


### PR DESCRIPTION
Now it is possible to apply the `evaluate()` function multiple times without getting an error.
The problem was the function `_format_for_anomaly_detector()` in which the drop of label columns of the dataframe was done with  inplace operations.  
Now the operations are no more inplace. 