### PR TITLE
Fix the evaluation strategy

### DIFF
--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -88,7 +88,9 @@ class Evaluator():
             dataset_copies.append(dataset_copy)
         return dataset_copies
 
-    def evaluate(self,models={},granularity='point'):
+    def evaluate(self,models={},granularity='point',strategy='flags'):
+        if strategy != 'flags':
+            raise NotImplementedError(f'Evaluation strategy {strategy} is not implemented')
         if not models:
             raise ValueError('There are no models to evaluate')
         if not self.test_data:

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -57,14 +57,18 @@ def _calculate_model_scores(single_model_evaluation={}):
     false_positives_count = 0
     anomalies_ratio = 0
     false_positives_ratio = 0
+    anomalous_series_n = 0
     for sample in single_model_evaluation.keys():
         anomalies_count += single_model_evaluation[sample]['anomalies_count']
-        anomalies_ratio += single_model_evaluation[sample]['anomalies_ratio']
+        if single_model_evaluation[sample]['anomalies_ratio'] is not None:
+            anomalies_ratio += single_model_evaluation[sample]['anomalies_ratio']
+        else:
+            anomalous_series_n += 1
         false_positives_count += single_model_evaluation[sample]['false_positives_count']
         false_positives_ratio += single_model_evaluation[sample]['false_positives_ratio']
 
     model_scores['anomalies_count'] = anomalies_count
-    model_scores['anomalies_ratio'] = anomalies_ratio/len(single_model_evaluation)
+    model_scores['anomalies_ratio'] = anomalies_ratio/(len(single_model_evaluation) - anomalous_series_n)
     model_scores['false_positives_count'] = false_positives_count
     model_scores['false_positives_ratio'] = false_positives_ratio/len(single_model_evaluation)
 
@@ -159,7 +163,10 @@ def _variable_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
     one_series_evaluation_result['false_positives_count'] = detection_counts_by_anomaly_type.pop(None)
     one_series_evaluation_result['false_positives_ratio'] = one_series_evaluation_result['false_positives_count']/normalization_factor
     one_series_evaluation_result['anomalies_count'] = total_detected_anomalies_n
-    one_series_evaluation_result['anomalies_ratio'] = total_detected_anomalies_n/total_inserted_anomalies_n
+    if total_inserted_anomalies_n:
+        one_series_evaluation_result['anomalies_ratio'] = total_detected_anomalies_n/total_inserted_anomalies_n
+    else:
+        one_series_evaluation_result['anomalies_ratio'] = None
     return one_series_evaluation_result
 
 def _point_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
@@ -187,7 +194,10 @@ def _point_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
     one_series_evaluation_result['false_positives_count'] = detection_counts_by_anomaly_type.pop(None)
     one_series_evaluation_result['false_positives_ratio'] = one_series_evaluation_result['false_positives_count']/normalization_factor
     one_series_evaluation_result['anomalies_count'] = total_detected_anomalies_n
-    one_series_evaluation_result['anomalies_ratio'] = total_detected_anomalies_n/total_inserted_anomalies_n
+    if total_inserted_anomalies_n:
+        one_series_evaluation_result['anomalies_ratio'] = total_detected_anomalies_n/total_inserted_anomalies_n
+    else:
+        one_series_evaluation_result['anomalies_ratio'] = None
     return one_series_evaluation_result
 
 def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -110,7 +110,7 @@ class Evaluator():
                 if granularity == 'series':
                     single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i])
                 
-            models_scores[model_name] = _calculate_model_scores(single_model_evaluation,granularity=granularity)
+            models_scores[model_name] = _calculate_model_scores(single_model_evaluation)
             j+=1
 
         return models_scores

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -62,13 +62,12 @@ def _calculate_model_scores(single_model_evaluation={}):
         anomalies_count += single_model_evaluation[sample]['anomalies_count']
         if single_model_evaluation[sample]['anomalies_ratio'] is not None:
             anomalies_ratio += single_model_evaluation[sample]['anomalies_ratio']
-        else:
             anomalous_series_n += 1
         false_positives_count += single_model_evaluation[sample]['false_positives_count']
         false_positives_ratio += single_model_evaluation[sample]['false_positives_ratio']
 
     model_scores['anomalies_count'] = anomalies_count
-    model_scores['anomalies_ratio'] = anomalies_ratio/(len(single_model_evaluation) - anomalous_series_n)
+    model_scores['anomalies_ratio'] = anomalies_ratio/anomalous_series_n
     model_scores['false_positives_count'] = false_positives_count
     model_scores['false_positives_ratio'] = false_positives_ratio/len(single_model_evaluation)
 

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -88,7 +88,7 @@ class Evaluator():
             dataset_copies.append(dataset_copy)
         return dataset_copies
 
-    def evaluate(self,models={},granularity='data_point'):
+    def evaluate(self,models={},granularity='point'):
         if not models:
             raise ValueError('There are no models to evaluate')
         if not self.test_data:
@@ -109,7 +109,7 @@ class Evaluator():
             single_model_evaluation = {}
             flagged_dataset = _get_model_output(dataset_copies[j],model)
             for i,sample_df in enumerate(flagged_dataset):
-                if granularity == 'data_point':
+                if granularity == 'point':
                     single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels_list[i])
                 elif granularity == 'variable':
                     single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels_list[i])

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -111,10 +111,12 @@ class Evaluator():
             for i,sample_df in enumerate(flagged_dataset):
                 if granularity == 'data_point':
                     single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels_list[i])
-                if granularity == 'variable':
+                elif granularity == 'variable':
                     single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels_list[i])
-                if granularity == 'series':
+                elif granularity == 'series':
                     single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i])
+                else:
+                    raise ValueError(f'Unknown granularity {granularity}')
                 
             models_scores[model_name] = _calculate_model_scores(single_model_evaluation)
             j+=1

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -67,7 +67,10 @@ def _calculate_model_scores(single_model_evaluation={}):
         false_positives_ratio += single_model_evaluation[sample]['false_positives_ratio']
 
     model_scores['anomalies_count'] = anomalies_count
-    model_scores['anomalies_ratio'] = anomalies_ratio/anomalous_series_n
+    if anomalous_series_n:
+        model_scores['anomalies_ratio'] = anomalies_ratio/anomalous_series_n
+    else:
+        model_scores['anomalies_ratio'] = None
     model_scores['false_positives_count'] = false_positives_count
     model_scores['false_positives_ratio'] = false_positives_ratio/len(single_model_evaluation)
 
@@ -215,6 +218,6 @@ def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
     one_series_evaluation_result['false_positives_count'] = 1 if is_series_anomalous and not anomalies else 0
     one_series_evaluation_result['false_positives_ratio'] = one_series_evaluation_result['false_positives_count']
     one_series_evaluation_result['anomalies_count'] = 1 if is_series_anomalous and anomalies else 0
-    one_series_evaluation_result['anomalies_ratio'] = one_series_evaluation_result['anomalies_count']
+    one_series_evaluation_result['anomalies_ratio'] = one_series_evaluation_result['anomalies_count'] if anomalies else None
 
     return one_series_evaluation_result

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -166,7 +166,12 @@ def _point_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
     one_series_evaluation_result = {}
     normalization_factor = len(flagged_timeseries_df)
 
+    total_inserted_anomalies_n = 0
+    total_detected_anomalies_n = 0
+    detection_counts_by_anomaly_type = {}
     for anomaly,frequency in anomaly_labels_df.value_counts(dropna=False).items():
+        if anomaly is not None:
+            total_inserted_anomalies_n += frequency
         anomaly_count = 0
         for timestamp in flagged_timeseries_df.index:
             if anomaly_labels_df[timestamp] == anomaly:
@@ -174,9 +179,15 @@ def _point_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):
                     if flagged_timeseries_df.loc[timestamp,column]:
                         anomaly_count += 1
                         break
+        if anomaly is not None:
+            total_detected_anomalies_n += anomaly_count
+        detection_counts_by_anomaly_type[anomaly] = anomaly_count
         one_series_evaluation_result[anomaly] = anomaly_count / normalization_factor
 
-    one_series_evaluation_result['false_positives'] = one_series_evaluation_result.pop(None)
+    one_series_evaluation_result['false_positives_count'] = detection_counts_by_anomaly_type.pop(None)
+    one_series_evaluation_result['false_positives_ratio'] = one_series_evaluation_result['false_positives_count']/normalization_factor
+    one_series_evaluation_result['anomalies_count'] = total_detected_anomalies_n
+    one_series_evaluation_result['anomalies_ratio'] = total_detected_anomalies_n/total_inserted_anomalies_n
     return one_series_evaluation_result
 
 def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df):

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -318,15 +318,7 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],31/126)
 
     def test_evaluate_series_granularity(self):
-        anomalies = ['step_uv']
-        effects = []
-        series_generator = HumiTempTimeseriesGenerator()
-        # series_1 will be a true anomaly for the minmax
-        series_1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        # series_2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
-        series_2 = series_generator.generate(include_effect_label=True, anomalies=[],effects=effects)
-        dataset = [series_1,series_2]
-        evaluator = Evaluator(test_data=dataset)
+        dataset = [self.series1, self.series2, self.series3]
         minmax1 = MinMaxAnomalyDetector()
         minmax2 = MinMaxAnomalyDetector()
         minmax3 = MinMaxAnomalyDetector()
@@ -334,19 +326,12 @@ class TestEvaluators(unittest.TestCase):
                 'detector_2': minmax2,
                 'detector_3': minmax3
                 }
+        evaluator = Evaluator(test_data=dataset)
         evaluation_results = evaluator.evaluate(models=models,granularity='series')
-        # Evaluation_results:
-        # detector_1: {'step_uv': 0.5, 'false_positives': 0.5}
-        # detector_2: {'step_uv': 0.5, 'false_positives': 0.5}
-        # detector_3: {'step_uv': 0.5, 'false_positives': 0.5}
-
-        self.assertIsInstance(evaluation_results,dict)
-        self.assertEqual(len(evaluation_results),3)
-        self.assertEqual(len(evaluation_results['detector_1']),2)
-        self.assertEqual(len(evaluation_results['detector_2']),2)
-        self.assertEqual(len(evaluation_results['detector_3']),2)
-        self.assertAlmostEqual(evaluation_results['detector_1']['step_uv'],0.5)
-        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives'],0.5)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],2/3)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],1)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],1/3)
 
     def test_series_granularity_eval_with_non_detected_anomalies(self):
         effects = []

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -26,8 +26,8 @@ class TestEvaluators(unittest.TestCase):
         rnd.seed(123)
         np.random.seed(123)
 
-        series1 = generate_timeseries_df(entries=5, variables=2)
-        series1['anomaly_label'] = [None, 'anomaly_2', 'anomaly_1', None, 'anomaly_1']
+        self.series1 = generate_timeseries_df(entries=5, variables=2)
+        self.series1['anomaly_label'] = [None, 'anomaly_2', 'anomaly_1', None, 'anomaly_1']
         # series1
         # timestamp                  value_1   value_2      anomaly_label                                               
         # 2025-06-10 14:00:00+00:00  0.000000  0.707107          None
@@ -35,8 +35,8 @@ class TestEvaluators(unittest.TestCase):
         # 2025-06-10 16:00:00+00:00  0.909297  0.348710     anomaly_1
         # 2025-06-10 17:00:00+00:00  0.141120 -0.600243          None
         # 2025-06-10 18:00:00+00:00 -0.756802 -0.997336     anomaly_1
-        series2 = generate_timeseries_df(entries=7, variables=2)
-        series2['anomaly_label'] = ['anomaly_1', 'anomaly_2', 'anomaly_1', None, 'anomaly_1', None, None]
+        self.series2 = generate_timeseries_df(entries=7, variables=2)
+        self.series2['anomaly_label'] = ['anomaly_1', 'anomaly_2', 'anomaly_1', None, 'anomaly_1', None, None]
         # series2
         # timestamp                  value_1   value_2      anomaly_label
         # 2025-06-10 14:00:00+00:00  0.000000  0.707107     anomaly_1

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -297,7 +297,7 @@ class TestEvaluators(unittest.TestCase):
         evaluator = Evaluator(test_data=dataset)
         evaluation_results = evaluator.evaluate(models=models,granularity='data_point')
         self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],6)
-        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],7/12)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],7/8)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],4)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],8/21)
 

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -26,6 +26,27 @@ class TestEvaluators(unittest.TestCase):
         rnd.seed(123)
         np.random.seed(123)
 
+        series1 = generate_timeseries_df(entries=5, variables=2)
+        series1['anomaly_label'] = [None, 'anomaly_2', 'anomaly_1', None, 'anomaly_1']
+        # series1
+        # timestamp                  value_1   value_2      anomaly_label                                               
+        # 2025-06-10 14:00:00+00:00  0.000000  0.707107          None
+        # 2025-06-10 15:00:00+00:00  0.841471  0.977061     anomaly_2
+        # 2025-06-10 16:00:00+00:00  0.909297  0.348710     anomaly_1
+        # 2025-06-10 17:00:00+00:00  0.141120 -0.600243          None
+        # 2025-06-10 18:00:00+00:00 -0.756802 -0.997336     anomaly_1
+        series2 = generate_timeseries_df(entries=7, variables=2)
+        series2['anomaly_label'] = ['anomaly_1', 'anomaly_2', 'anomaly_1', None, 'anomaly_1', None, None]
+        # series2
+        # timestamp                  value_1   value_2      anomaly_label
+        # 2025-06-10 14:00:00+00:00  0.000000  0.707107     anomaly_1
+        # 2025-06-10 15:00:00+00:00  0.841471  0.977061     anomaly_2
+        # 2025-06-10 16:00:00+00:00  0.909297  0.348710     anomaly_1
+        # 2025-06-10 17:00:00+00:00  0.141120 -0.600243          None
+        # 2025-06-10 18:00:00+00:00 -0.756802 -0.997336     anomaly_1
+        # 2025-06-10 19:00:00+00:00 -0.958924 -0.477482          None
+        # 2025-06-10 20:00:00+00:00 -0.279415  0.481366          None
+
     def test_evaluate_anomaly_detector(self):
 
         min_max_anomaly_detector = MinMaxAnomalyDetector()

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -333,48 +333,6 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],1)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],1/3)
 
-    def test_series_granularity_eval_with_non_detected_anomalies(self):
-        effects = []
-        series_generator = HumiTempTimeseriesGenerator()
-        # series_1 will be a true anomaly for the minmax
-        series_1 = series_generator.generate(include_effect_label=True, anomalies=['step_uv'],effects=effects)
-        # series_2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
-        series_2 = series_generator.generate(include_effect_label=True, anomalies=['pattern_uv'],effects=effects)
-        dataset = [series_1,series_2]
-        evaluator = Evaluator(test_data=dataset)
-        minmax1 = MinMaxAnomalyDetector()
-        minmax2 = MinMaxAnomalyDetector()
-        minmax3 = MinMaxAnomalyDetector()
-        models={'detector_1': minmax1,
-                'detector_2': minmax2,
-                'detector_3': minmax3
-                }
-        evaluation_results = evaluator.evaluate(models=models,granularity='series')
-        # Evaluation_results:
-        # detector_1: {'step_uv': 0.5, 'pattern_uv': 0.5, 'false_positives': 0.0}
-        # detector_2: {'step_uv': 0.5, 'pattern_uv': 0.5, 'false_positives': 0.0}
-        # detector_3: {'step_uv': 0.5, 'pattern_uv': 0.5, 'false_positives': 0.0}
-        self.assertIsInstance(evaluation_results,dict)
-        self.assertEqual(len(evaluation_results),3)
-        self.assertEqual(len(evaluation_results['detector_1']),3)
-        self.assertEqual(len(evaluation_results['detector_2']),3)
-        self.assertEqual(len(evaluation_results['detector_3']),3)
-        self.assertAlmostEqual(evaluation_results['detector_1']['step_uv'],0.5)
-        self.assertAlmostEqual(evaluation_results['detector_1']['pattern_uv'],0.5)
-        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives'],0.0)
-
-    def test_raised_error_evaluation_series_granularity(self):
-        anomalies = ['step_uv','spike_uv']
-        series_generator = HumiTempTimeseriesGenerator()
-        series = series_generator.generate(include_effect_label=True, anomalies=anomalies)
-        dataset = [series]
-        minmax = MinMaxAnomalyDetector()
-        evaluator = Evaluator(test_data=dataset)
-        try:
-            evaluation_result = evaluator.evaluate(models={'detector':minmax},granularity='series')
-        except Exception as e:
-            self.assertIsInstance(e,ValueError)
-
     def test_copy_dataset(self):
         series_generator = HumiTempTimeseriesGenerator()
         series_1 = series_generator.generate(include_effect_label=True, effects=['noise'])

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -46,6 +46,8 @@ class TestEvaluators(unittest.TestCase):
         # 2025-06-10 18:00:00+00:00 -0.756802 -0.997336     anomaly_1
         # 2025-06-10 19:00:00+00:00 -0.958924 -0.477482          None
         # 2025-06-10 20:00:00+00:00 -0.279415  0.481366          None
+        self.series3 = generate_timeseries_df(entries=3, variables=2)
+        self.series3['anomaly_label'] = [None, None, None]
 
     def test_evaluate_anomaly_detector(self):
 

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -302,14 +302,7 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],8/21)
 
     def test_evaluate_variable_granularity(self):
-        anomalies = ['step_uv']
-        effects = []
-        # series with 2880 data points
-        series_generator = HumiTempTimeseriesGenerator()
-        series_1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        series_2 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        dataset = [series_1,series_2]
-        evaluator = Evaluator(test_data=dataset)
+        dataset = [self.series1, self.series2, self.series3]
         minmax1 = MinMaxAnomalyDetector()
         minmax2 = MinMaxAnomalyDetector()
         minmax3 = MinMaxAnomalyDetector()
@@ -317,19 +310,12 @@ class TestEvaluators(unittest.TestCase):
                 'detector_2': minmax2,
                 'detector_3': minmax3
                 }
+        evaluator = Evaluator(test_data=dataset)
         evaluation_results = evaluator.evaluate(models=models,granularity='variable')
-        # Evaluation_results:
-        # detector_1: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
-        # detector_2: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
-        # detector_3: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
-
-        self.assertIsInstance(evaluation_results,dict)
-        self.assertEqual(len(evaluation_results),3)
-        self.assertEqual(len(evaluation_results['detector_1']),2)
-        self.assertEqual(len(evaluation_results['detector_2']),2)
-        self.assertEqual(len(evaluation_results['detector_3']),2)
-        self.assertAlmostEqual(evaluation_results['detector_1']['step_uv'],0.000694444444444444)
-        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives'],0.000694444444444444)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],7)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],25/48)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],5)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],31/126)
 
     def test_evaluate_series_granularity(self):
         anomalies = ['step_uv']

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -286,14 +286,7 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(model_scores['false_positives_ratio'],0.14)
 
     def test_evaluate_point_granularity(self):
-        anomalies = ['step_uv']
-        effects = []
-        # series with 2880 data points
-        series_generator = HumiTempTimeseriesGenerator()
-        series_1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        series_2 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        dataset = [series_1,series_2]
-        evaluator = Evaluator(test_data=dataset)
+        dataset = [self.series1, self.series2, self.series3]
         minmax1 = MinMaxAnomalyDetector()
         minmax2 = MinMaxAnomalyDetector()
         minmax3 = MinMaxAnomalyDetector()
@@ -301,18 +294,12 @@ class TestEvaluators(unittest.TestCase):
                 'detector_2': minmax2,
                 'detector_3': minmax3
                 }
+        evaluator = Evaluator(test_data=dataset)
         evaluation_results = evaluator.evaluate(models=models,granularity='data_point')
-        # Evaluation_results:
-        # detector_1: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
-        # detector_2: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
-        # detector_3: {'step_uv': 0.000694444444444444, 'false_positives': 0.000694444444444444}
-        self.assertIsInstance(evaluation_results,dict)
-        self.assertEqual(len(evaluation_results),3)
-        self.assertEqual(len(evaluation_results['detector_1']),2)
-        self.assertEqual(len(evaluation_results['detector_2']),2)
-        self.assertEqual(len(evaluation_results['detector_3']),2)
-        self.assertAlmostEqual(evaluation_results['detector_1']['step_uv'],0.000694444444444444)
-        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives'],0.000694444444444444)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],6)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],7/12)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],4)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],8/21)
 
     def test_evaluate_variable_granularity(self):
         anomalies = ['step_uv']

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -324,9 +324,9 @@ class TestEvaluators(unittest.TestCase):
         effects = []
         # series with 2880 data points
         series_generator = HumiTempTimeseriesGenerator()
-        series1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        series2 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        dataset = [series1,series2]
+        series_1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
+        series_2 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
+        dataset = [series_1,series_2]
         evaluator = Evaluator(test_data=dataset)
         minmax1 = MinMaxAnomalyDetector()
         minmax2 = MinMaxAnomalyDetector()
@@ -353,9 +353,9 @@ class TestEvaluators(unittest.TestCase):
         effects = []
         # series with 2880 data points
         series_generator = HumiTempTimeseriesGenerator()
-        series1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        series2 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        dataset = [series1,series2]
+        series_1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
+        series_2 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
+        dataset = [series_1,series_2]
         evaluator = Evaluator(test_data=dataset)
         minmax1 = MinMaxAnomalyDetector()
         minmax2 = MinMaxAnomalyDetector()
@@ -382,11 +382,11 @@ class TestEvaluators(unittest.TestCase):
         anomalies = ['step_uv']
         effects = []
         series_generator = HumiTempTimeseriesGenerator()
-        # series1 will be a true anomaly for the minmax
-        series1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        # series2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
-        series2 = series_generator.generate(include_effect_label=True, anomalies=[],effects=effects)
-        dataset = [series1,series2]
+        # series_1 will be a true anomaly for the minmax
+        series_1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
+        # series_2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
+        series_2 = series_generator.generate(include_effect_label=True, anomalies=[],effects=effects)
+        dataset = [series_1,series_2]
         evaluator = Evaluator(test_data=dataset)
         minmax1 = MinMaxAnomalyDetector()
         minmax2 = MinMaxAnomalyDetector()
@@ -412,11 +412,11 @@ class TestEvaluators(unittest.TestCase):
     def test_series_granularity_eval_with_non_detected_anomalies(self):
         effects = []
         series_generator = HumiTempTimeseriesGenerator()
-        # series1 will be a true anomaly for the minmax
-        series1 = series_generator.generate(include_effect_label=True, anomalies=['step_uv'],effects=effects)
-        # series2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
-        series2 = series_generator.generate(include_effect_label=True, anomalies=['pattern_uv'],effects=effects)
-        dataset = [series1,series2]
+        # series_1 will be a true anomaly for the minmax
+        series_1 = series_generator.generate(include_effect_label=True, anomalies=['step_uv'],effects=effects)
+        # series_2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
+        series_2 = series_generator.generate(include_effect_label=True, anomalies=['pattern_uv'],effects=effects)
+        dataset = [series_1,series_2]
         evaluator = Evaluator(test_data=dataset)
         minmax1 = MinMaxAnomalyDetector()
         minmax2 = MinMaxAnomalyDetector()
@@ -453,9 +453,9 @@ class TestEvaluators(unittest.TestCase):
 
     def test_copy_dataset(self):
         series_generator = HumiTempTimeseriesGenerator()
-        series1 = series_generator.generate(include_effect_label=True, effects=['noise'])
-        series2 = series_generator.generate(include_effect_label=True, effects=['noise'])
-        dataset = [series1,series2]
+        series_1 = series_generator.generate(include_effect_label=True, effects=['noise'])
+        series_2 = series_generator.generate(include_effect_label=True, effects=['noise'])
+        dataset = [series_1,series_2]
         evaluator = Evaluator(test_data=dataset)
         minmax1 = MinMaxAnomalyDetector()
         minmax2 = MinMaxAnomalyDetector()
@@ -510,9 +510,9 @@ class TestEvaluators(unittest.TestCase):
         self.assertEqual(len(evaluation_result),1)
         self.assertAlmostEqual(evaluation_result['step_uv'],1)
 
-        series1 = series_generator.generate(include_effect_label=True, anomalies=[])
+        series_1 = series_generator.generate(include_effect_label=True, anomalies=[])
         minmax1 = MinMaxAnomalyDetector()
-        formatted_series1,anomaly_labels1 = _format_for_anomaly_detector(series1,synthetic=True)
+        formatted_series1,anomaly_labels1 = _format_for_anomaly_detector(series_1,synthetic=True)
         flagged_series1 = minmax.apply(formatted_series1)
         evaluation_result1 = _series_granularity_evaluation(flagged_series1,anomaly_labels1)
         self.assertEqual(len(evaluation_result1),1)
@@ -522,8 +522,8 @@ class TestEvaluators(unittest.TestCase):
         # }
 
         try:
-            series2 = series_generator.generate(include_effect_label=True, anomalies=['spike_uv','step_uv'])
-            formatted_series2,anomaly_labels2 = _format_for_anomaly_detector(series2,synthetic=True)
+            series_2 = series_generator.generate(include_effect_label=True, anomalies=['spike_uv','step_uv'])
+            formatted_series2,anomaly_labels2 = _format_for_anomaly_detector(series_2,synthetic=True)
             flagged_series2 = minmax.apply(formatted_series2)
             evaluation_result2 = _series_granularity_evaluation(flagged_series2,anomaly_labels2)
         except Exception as e:
@@ -533,11 +533,11 @@ class TestEvaluators(unittest.TestCase):
         anomalies = ['step_uv']
         effects = []
         series_generator = HumiTempTimeseriesGenerator()
-        # series1 will be a true anomaly for the minmax
-        series1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
-        # series2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
-        series2 = series_generator.generate(include_effect_label=True, anomalies=[],effects=effects)
-        dataset = [series1,series2]
+        # series_1 will be a true anomaly for the minmax
+        series_1 = series_generator.generate(include_effect_label=True, anomalies=anomalies,effects=effects)
+        # series_2 will be a false positive for minmax (it sees always 2 anomalous data points for each variable)
+        series_2 = series_generator.generate(include_effect_label=True, anomalies=[],effects=effects)
+        dataset = [series_1,series_2]
         evaluator = Evaluator(test_data=dataset)
         minmax1 = MinMaxAnomalyDetector()
         minmax2 = MinMaxAnomalyDetector()

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -468,19 +468,30 @@ class TestEvaluators(unittest.TestCase):
         self.assertEqual(len(dataset_copies[1]),2)
 
     def test_variable_granularity_evaluation(self):
-        series_generator = HumiTempTimeseriesGenerator()
-        series = series_generator.generate(include_effect_label=True, anomalies=['step_uv'])
-        minmax = MinMaxAnomalyDetector()
-        formatted_series,anomaly_labels = _format_for_anomaly_detector(series,synthetic=True)
-        flagged_series = minmax.apply(formatted_series)
-        evaluation_result = _variable_granularity_evaluation(flagged_series,anomaly_labels)
-        # evaluation_result:
-        # { 'step_uv': 0.00034722222222222224
-        # 'false_positives': 0.00034722222222222224
-        # }
-        self.assertEqual(len(evaluation_result),2)
-        self.assertAlmostEqual(evaluation_result['step_uv'],1/len(series))
-        self.assertAlmostEqual(evaluation_result['false_positives'],1/len(series))
+        dataset = [self.series1]
+        evaluator = Evaluator(test_data=dataset)
+        minmax1 = MinMaxAnomalyDetector()
+        models={'detector_1': minmax1}
+        evaluator = Evaluator(test_data=dataset)
+        evaluation_results = evaluator.evaluate(models=models,granularity='variable')
+        self.assertIn('detector_1',evaluation_results.keys())
+        self.assertIn('anomalies_count',evaluation_results['detector_1'].keys())
+        self.assertIn('anomalies_ratio',evaluation_results['detector_1'].keys())
+        self.assertIn('false_positives_count',evaluation_results['detector_1'].keys())
+        self.assertIn('false_positives_ratio',evaluation_results['detector_1'].keys())
+
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],4)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],4/6)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],0)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],0)
+
+        dataset1 = [self.series2]
+        evaluator1 = Evaluator(test_data=dataset1)
+        evaluation_results = evaluator1.evaluate(models=models,granularity='variable')
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],3)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],3/8)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],1)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],1/(7*2))
 
     def test_point_granularity_evaluation(self):
         series_generator = HumiTempTimeseriesGenerator()

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -295,7 +295,7 @@ class TestEvaluators(unittest.TestCase):
                 'detector_3': minmax3
                 }
         evaluator = Evaluator(test_data=dataset)
-        evaluation_results = evaluator.evaluate(models=models,granularity='data_point')
+        evaluation_results = evaluator.evaluate(models=models,granularity='point')
         self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],6)
         self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],7/8)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],4)
@@ -381,7 +381,7 @@ class TestEvaluators(unittest.TestCase):
         minmax1 = MinMaxAnomalyDetector()
         models={'detector_1': minmax1}
         evaluator = Evaluator(test_data=dataset)
-        evaluation_results = evaluator.evaluate(models=models,granularity='data_point')
+        evaluation_results = evaluator.evaluate(models=models,granularity='point')
         self.assertIn('detector_1',evaluation_results.keys())
         self.assertIn('anomalies_count',evaluation_results['detector_1'].keys())
         self.assertIn('anomalies_ratio',evaluation_results['detector_1'].keys())
@@ -395,7 +395,7 @@ class TestEvaluators(unittest.TestCase):
 
         dataset1 = [self.series2]
         evaluator1 = Evaluator(test_data=dataset1)
-        evaluation_results = evaluator1.evaluate(models=models,granularity='data_point')
+        evaluation_results = evaluator1.evaluate(models=models,granularity='point')
         self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],3)
         self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],3/4)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],1)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -329,7 +329,7 @@ class TestEvaluators(unittest.TestCase):
         evaluator = Evaluator(test_data=dataset)
         evaluation_results = evaluator.evaluate(models=models,granularity='series')
         self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],2)
-        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],2/3)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],2/2)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],1)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],1/3)
 
@@ -423,7 +423,7 @@ class TestEvaluators(unittest.TestCase):
         evaluator1 = Evaluator(test_data=dataset1)
         evaluation_results = evaluator1.evaluate(models=models,granularity='series')
         self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],0)
-        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],0)
+        self.assertIsNone(evaluation_results['detector_1']['anomalies_ratio'])
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],1)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],1)
 


### PR DESCRIPTION
The new parameter `strategy` sets the evaluation strategy. Supported values are:
- `strategy = 'flags'`: detected anomalies are counted matching the anomaly labels in the series and the anomaly flag of the model, one by one. This is the default evaluation strategy. 
- `strategy = 'events'`:  Not yet implemented, will group anomaly flags in events.

The parameter `granularity` sets the "finesse" of the evaluation and affects how detected, inserted anomalies and false positives are counted. The evaluation logic has been fixed and improved. The available granularities are:
- `granularity = 'variable'` : anomalies and false positives are counted for each variable of the series
-  `granularity = 'point'`:  anomalies and false positives are counted for each timestamp
- `granularity = 'series'`:  anomalies and false positives are counted for each series, so a series can be either anomalous or not

In the module "evaluators.py" there are 3 private functions aimed at the evaluation of the model on a single series: `_variable_granularity_evaluation()`, `_point_granularity_evaluation()`, `_series_granularity_evaluation()`.  As names suggest, each function evaluate with a specific granularity.

Given:
$N_d=$ n. of correctly detected anomalies
$N_{tot}=$  n. of inserted anomalies
$K=$ normalization factor
$N_{FP}$ = n. of false positives
$N_p=$ series length
$n=$ series dimension

The output of the above functions is a dictionary with 4 couples key-value:
1) **anomalies_count**: $N_d$
2) **anomalies_ratio**: $\frac{N_d}{N_{tot}}$
If there are no anomalies, the value is "None"
3) **false_positives_count**: $N_{FP}$
4) **false_positives_ratio**: $\frac{N_{FP} }{K}$

| K | granularity |
|----------|-----------|
|   $N_p\times n$    | `'variable'`  |
|     $N_p$     | `'point'`  |
|       1   |    `'series'`  |

The evaluation of the model on the dataset is assembled in the private function `_calculate_model_scores()`. This function takes in input the evaluations on the single series (each done with a fixed granularity) and it returns a dictionary with the structure already discussed: what changes are the values. If $N$ is the number of series in the dataset:
1) **anomalies_count**: $\sum_{i=1}^{N}N_d^{i}$
2) **anomalies_ratio**: $\frac{1}{N_A}\sum_{i=1}^{N_A}\frac{N_d^{i}}{N^{i}_{tot}}$. 
If there are no anomalies, the value is "None"
3) **false_positive_count**: $\sum_{i=1}^{N}N_{FP}^{i}$
4) **false_positive_ratio**: $\frac{1}{N}\sum_{i=1}^{N}\frac{N_{FP}^{i} }{K}$

$N_A$ states for number of series in the dataset with at least 1 anomaly.

In the following, an example of evaluation using the `MinMaxAnomalyDetector()` and series generated with `generate_timeseries_df()`:
**series1**
| timestamp                  | value_1   | value_2   | anomaly_label | value_1_anomaly | value_2_anomaly |
|---------------------------|-----------|-----------|----------------|------------------|------------------|
| 2025-06-10 14:00:00+00:00 | 0.000000  | 0.707107  | None           | 0                | 0                |
| 2025-06-10 15:00:00+00:00 | 0.841471  | 0.977061  | anomaly_2      | 0                | 1                |
| 2025-06-10 16:00:00+00:00 | 0.909297  | 0.348710  | anomaly_1      | 1                | 0                |
| 2025-06-10 17:00:00+00:00 | 0.141120  | -0.600243 | None           | 0                | 0                |
| 2025-06-10 18:00:00+00:00 | -0.756802 | -0.997336 | anomaly_1      | 1                | 1                |

**series2**
| timestamp                  | value_1   | value_2   | anomaly_label | value_1_anomaly | value_2_anomaly |
|---------------------------|-----------|-----------|----------------|------------------|------------------|
| 2025-06-10 14:00:00+00:00 | 0.000000  | 0.707107  | anomaly_1      | 0                | 0                |
| 2025-06-10 15:00:00+00:00 | 0.841471  | 0.977061  | anomaly_2      | 0                | 1                |
| 2025-06-10 16:00:00+00:00 | 0.909297  | 0.348710  | anomaly_1      | 1                | 0                |
| 2025-06-10 17:00:00+00:00 | 0.141120  | -0.600243 | None           | 0                | 0                |
| 2025-06-10 18:00:00+00:00 | -0.756802 | -0.997336 | anomaly_1      | 0                | 1                |
| 2025-06-10 19:00:00+00:00 | -0.958924 | -0.477482 | None           | 1                | 0                |
| 2025-06-10 20:00:00+00:00 | -0.279415 | 0.481366  | None           | 0                | 0                |

**series3**
| timestamp                  | value_1   | value_2   | anomaly_label | value_1_anomaly | value_2_anomaly |
|---------------------------|-----------|-----------|----------------|------------------|------------------|
| 2025-06-10 14:00:00+00:00 | 0.000000  | 0.707107  | None      | 1                | 0                |
| 2025-06-10 15:00:00+00:00 | 0.841471  | 0.977061  | None      | 0                | 1                |
| 2025-06-10 16:00:00+00:00 | 0.909297  | 0.348710  | None      | 1                | 1                |

The columns 'value_1_anomaly' and 'value_2_anomaly' are the result of model: 1 means anomalous, while 0 not anomalous.
Here the result of the evaluation on this dataset, using the 3 different granularities:
```
dataset = [series1, series2, series3]
minmax =  MinMaxAnomalyDetector()
models = {'my_model': minmax}
evaluator = Evaluator(test_data=dataset)
```
```
evaluation_result = evaluator.evaluate(models,granularity='variable')
{'anomalies_count': 7,
 'anomalies_ratio': 0.5208333333333333,
 'false_positives_count': 5,
 'false_positives_ratio': 0.24603174603174602}
```
```
evaluation_result = evaluator.evaluate(models,granularity='data_point')
{'anomalies_count': 6,
 'anomalies_ratio': 0.875,
 'false_positives_count': 4,
 'false_positives_ratio': 0.38095238095238093}
```
```
evaluation_result = evaluator.evaluate(models,granularity='series')
{'anomalies_count': 2,
 'anomalies_ratio': 1.0,
 'false_positives_count': 1,
 'false_positives_ratio': 0.3333333333333333}
```

**Notes:**

Some commits are about generating series inside the `setUp()` method in "test_evaluators.py", useful for testing the evaluation now and for the future. 

For now, the evaluation is based on the following assumption: if the timestamp t is marked as anomalous, the anomaly is present in all variables making up the series.

This PR partially addresses #56: the evaluation does not already distinguish between different type of anomalies. This will be done in the future adding the `breakdown` switch.

The `evaluate()` takes in input a dictionary {'model_name': model_instance}, so it can evaluate more than one model on the same dataset. The output for multiple models is a nested dictionary: its primary keys are model names and the coupled values are a dictionaries as the ones showed above.