### PR TITLE
Feature: evaluation breakdown

### DIFF
--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -114,7 +114,7 @@ class Evaluator():
                 elif granularity == 'variable':
                     single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
                 elif granularity == 'series':
-                    single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i])
+                    single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
                 else:
                     raise ValueError(f'Unknown granularity {granularity}')
             if breakdown:    

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -184,13 +184,14 @@ def _variable_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df,bre
         for timestamp in flagged_timeseries_df.index:
             if anomaly_labels_df[timestamp] == anomaly:
                 for column in flagged_timeseries_df.filter(like='anomaly').columns:
-                    anomaly_count += flagged_timeseries_df.loc[timestamp,column]
+                    if anomaly is not None:
+                        anomaly_count += flagged_timeseries_df.loc[timestamp,column]
+                    else:
+                        false_positives_count += flagged_timeseries_df.loc[timestamp,column]
         if anomaly is not None:
             total_detected_anomalies_n += anomaly_count
             breakdown_info[anomaly + '_anomaly' + '_count'] = anomaly_count
             breakdown_info[anomaly + '_anomaly' + '_ratio'] = anomaly_count/(frequency * variables_n)
-        else:
-            false_positives_count +=1
 
     total_inserted_anomalies_n *= variables_n
     one_series_evaluation_result['false_positives_count'] = false_positives_count

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -111,7 +111,7 @@ class Evaluator():
             dataset_copies.append(dataset_copy)
         return dataset_copies
 
-    def evaluate(self,models={},granularity='point',strategy='flags'):
+    def evaluate(self,models={},granularity='point',strategy='flags',breakdown=False):
         if strategy != 'flags':
             raise NotImplementedError(f'Evaluation strategy {strategy} is not implemented')
 

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -91,6 +91,7 @@ class Evaluator():
     def evaluate(self,models={},granularity='point',strategy='flags'):
         if strategy != 'flags':
             raise NotImplementedError(f'Evaluation strategy {strategy} is not implemented')
+
         if not models:
             raise ValueError('There are no models to evaluate')
         if not self.test_data:

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -142,10 +142,8 @@ class Evaluator():
                     single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
                 else:
                     raise ValueError(f'Unknown granularity {granularity}')
-            if breakdown:    
-                models_scores[model_name] = _calculate_model_scores(single_model_evaluation) | _get_breakdown_info(single_model_evaluation)
-            else:
-                models_scores[model_name] = _calculate_model_scores(single_model_evaluation)
+
+            models_scores[model_name] = _calculate_model_scores(single_model_evaluation)
             j+=1
 
         return models_scores
@@ -252,8 +250,6 @@ def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df,break
             anomalies.append(anomaly)
     if len(anomalies) != 1 and breakdown:
         raise ValueError('Series must have only 1 anomaly type for breakdown in mode granularity = "series"')
-    else:
-        inserted_anomaly = anomalies[0]
 
     one_series_evaluation_result = {}
     breakdown_info = {}
@@ -262,8 +258,10 @@ def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df,break
         for column in flagged_timeseries_df.filter(like='anomaly').columns:
             if flagged_timeseries_df.loc[timestamp,column]:
                 is_series_anomalous = 1
-                breakdown_info[inserted_anomaly + '_anomaly_count'] = 1
-                breakdown_info[inserted_anomaly + '_anomaly_ratio'] = 1
+                if anomalies:
+                    inserted_anomaly = anomalies[0]
+                    breakdown_info[inserted_anomaly + '_anomaly_count'] = 1
+                    breakdown_info[inserted_anomaly + '_anomaly_ratio'] = 1
                 break
     one_series_evaluation_result['false_positives_count'] = 1 if is_series_anomalous and not anomalies else 0
     one_series_evaluation_result['false_positives_ratio'] = one_series_evaluation_result['false_positives_count']

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -71,14 +71,15 @@ def _calculate_model_scores(single_model_evaluation={}):
     return model_scores
 
 def _get_breakdown_info(single_model_evaluation={}):
-    if 'anomalies_count' in single_model_evaluation.keys():
-        del single_model_evaluation['anomalies_count']
-    if 'anomalies_ratio' in single_model_evaluation.keys():
-        del single_model_evaluation['anomalies_ratio']
-    if 'false_positives_count' in single_model_evaluation.keys():
-        del single_model_evaluation['false_positives_count']
-    if 'false_positives_ratio' in single_model_evaluation.keys():
-        del single_model_evaluation['false_positives_ratio']
+    for sample in single_model_evaluation.keys():
+        if 'anomalies_count' in single_model_evaluation[sample].keys():
+            del single_model_evaluation[sample]['anomalies_count']
+        if 'anomalies_ratio' in single_model_evaluation[sample].keys():
+            del single_model_evaluation[sample]['anomalies_ratio']
+        if 'false_positives_count' in single_model_evaluation[sample].keys():
+            del single_model_evaluation[sample]['false_positives_count']
+        if 'false_positives_ratio' in single_model_evaluation[sample].keys():
+            del single_model_evaluation[sample]['false_positives_ratio']
 
     breakdown_info = {}
     # how many series in the dataset have that anomaly type
@@ -143,7 +144,12 @@ class Evaluator():
                 else:
                     raise ValueError(f'Unknown granularity {granularity}')
 
-            models_scores[model_name] = _calculate_model_scores(single_model_evaluation)
+            if breakdown:
+                scores = _calculate_model_scores(single_model_evaluation)
+                breakdown_info = _get_breakdown_info(single_model_evaluation)
+                models_scores[model_name] = scores | breakdown_info
+            else:
+                models_scores[model_name] = _calculate_model_scores(single_model_evaluation)
             j+=1
 
         return models_scores

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -70,8 +70,33 @@ def _calculate_model_scores(single_model_evaluation={}):
     model_scores['false_positives_ratio'] = false_positives_ratio/len(single_model_evaluation)
     return model_scores
 
-    def _get_breakdown_info(single_model_evaluation={}):
-        pass
+def _get_breakdown_info(single_model_evaluation={}):
+    if 'anomalies_count' in single_model_evaluation.keys():
+        del single_model_evaluation['anomalies_count']
+    if 'anomalies_ratio' in single_model_evaluation.keys():
+        del single_model_evaluation['anomalies_ratio']
+    if 'false_positives_count' in single_model_evaluation.keys():
+        del single_model_evaluation['false_positives_count']
+    if 'false_positives_ratio' in single_model_evaluation.keys():
+        del single_model_evaluation['false_positives_ratio']
+
+    breakdown_info = {}
+    # how many series in the dataset have that anomaly type
+    anomaly_series_count_by_type = {}
+    for sample, sample_evaluation in single_model_evaluation.items():
+        for key in sample_evaluation.keys():
+            if key in breakdown_info.keys():
+                anomaly_series_count_by_type[key] +=1
+                breakdown_info[key] += sample_evaluation[key]
+            else:
+                anomaly_series_count_by_type[key] =1
+                breakdown_info[key] = sample_evaluation[key]
+
+    for key in breakdown_info.keys():
+        if '_ratio' in key:
+            breakdown_info[key] /= anomaly_series_count_by_type[key]
+
+    return breakdown_info
 
 
 class Evaluator():

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -47,11 +47,6 @@ def evaluate_anomaly_detector(evaluated_timeseries_df, anomaly_labels, details=F
 
 
 def _calculate_model_scores(single_model_evaluation={}):
-    dataset_anomalies = set()
-    for sample in single_model_evaluation.keys():
-        sample_anomalies = set(single_model_evaluation[sample].keys())
-        dataset_anomalies.update(sample_anomalies)
-
     model_scores = {}
     anomalies_count = 0
     false_positives_count = 0
@@ -73,8 +68,10 @@ def _calculate_model_scores(single_model_evaluation={}):
         model_scores['anomalies_ratio'] = None
     model_scores['false_positives_count'] = false_positives_count
     model_scores['false_positives_ratio'] = false_positives_ratio/len(single_model_evaluation)
-
     return model_scores
+
+    def _get_breakdown_info(single_model_evaluation={}):
+        pass
 
 
 class Evaluator():
@@ -120,8 +117,10 @@ class Evaluator():
                     single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i])
                 else:
                     raise ValueError(f'Unknown granularity {granularity}')
-                
-            models_scores[model_name] = _calculate_model_scores(single_model_evaluation)
+            if breakdown:    
+                models_scores[model_name] = _calculate_model_scores(single_model_evaluation) | _get_breakdown_info(single_model_evaluation)
+            else:
+                models_scores[model_name] = _calculate_model_scores(single_model_evaluation)
             j+=1
 
         return models_scores

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -222,14 +222,16 @@ def _point_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df,breakd
             if anomaly_labels_df[timestamp] == anomaly:
                 for column in flagged_timeseries_df.filter(like='anomaly').columns:
                     if flagged_timeseries_df.loc[timestamp,column]:
-                        anomaly_count += 1
+                        if anomaly is not None:
+                            anomaly_count += 1
+                        else:
+                            false_positives_count += 1
                         break
         if anomaly is not None:
             total_detected_anomalies_n += anomaly_count
             breakdown_info[anomaly + '_anomaly_count'] = anomaly_count
             breakdown_info[anomaly + '_anomaly_ratio'] = anomaly_count/frequency
-        else:
-            false_positives_count += 1
+
         one_series_evaluation_result[anomaly] = anomaly_count / normalization_factor
 
     one_series_evaluation_result['false_positives_count'] = false_positives_count

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -136,7 +136,7 @@ class Evaluator():
             flagged_dataset = _get_model_output(dataset_copies[j],model)
             for i,sample_df in enumerate(flagged_dataset):
                 if granularity == 'point':
-                    single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels_list[i])
+                    single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels_list[i],breakdown=breakdown)
                 elif granularity == 'variable':
                     single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
                 elif granularity == 'series':
@@ -237,8 +237,6 @@ def _point_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df,breakd
             total_detected_anomalies_n += anomaly_count
             breakdown_info[anomaly + '_anomaly_count'] = anomaly_count
             breakdown_info[anomaly + '_anomaly_ratio'] = anomaly_count/frequency
-
-        one_series_evaluation_result[anomaly] = anomaly_count / normalization_factor
 
     one_series_evaluation_result['false_positives_count'] = false_positives_count
     one_series_evaluation_result['false_positives_ratio'] = false_positives_count/normalization_factor

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -541,6 +541,33 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(breakdown['pattern_anomaly_count'],2)
         self.assertAlmostEqual(breakdown['pattern_anomaly_ratio'],0.5)
 
+    def test_variable_granularity_eval_with_breakdown(self):
+        dataset = [self.series1, self.series2, self.series3]
+        minmax1 = MinMaxAnomalyDetector()
+        minmax2 = MinMaxAnomalyDetector()
+        minmax3 = MinMaxAnomalyDetector()
+        models={'detector_1': minmax1,
+                'detector_2': minmax2,
+                'detector_3': minmax3
+                }
+        evaluator = Evaluator(test_data=dataset)
+        evaluation_results = evaluator.evaluate(models=models,granularity='variable',breakdown=True)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],7)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],25/48)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],5)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],31/126)
+
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_count'],5)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_ratio'],13/24)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_count'],2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_ratio'],1/2)
+
+    def test_point_granularity_eval_with_breakdown(self):
+        pass
+
+    def test_series_granularity_eval_with_breakdown(self):
+        pass
+
     def test_double_evaluator(self):
         anomalies = ['step_uv']
         effects = []

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -583,6 +583,40 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_count'],2)
         self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_ratio'],1)
 
+    def test_series_granularity_eval_with_breakdown(self):
+        series_1 = generate_timeseries_df(entries=3, variables=2)
+        series_1['anomaly_label'] = [None,None,'anomaly_1']
+        series_2 = generate_timeseries_df(entries=3, variables=2)
+        series_2['anomaly_label'] = ['anomaly_1',None,None]
+        series_3 = generate_timeseries_df(entries=3, variables=2)
+        series_3['anomaly_label'] = [None,'anomaly_2',None]
+        dataset = [series_1, series_2, series_3]
+        minmax1 = MinMaxAnomalyDetector()
+        minmax2 = MinMaxAnomalyDetector()
+        minmax3 = MinMaxAnomalyDetector()
+        models={'detector_1': minmax1,
+                'detector_2': minmax2,
+                'detector_3': minmax3
+                }
+        evaluator = Evaluator(test_data=dataset)
+        evaluation_results = evaluator.evaluate(models=models,granularity='series',breakdown=True)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],3)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],1)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],0)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],0)
+
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_count'],2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_ratio'],1)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_count'],1)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_ratio'],1)
+
+        try:
+            dataset = [self.series1, self.series2, self.series3]
+            evaluator = Evaluator(test_data=dataset)
+            evaluation_results = evaluator.evaluate(models=models,granularity='series',breakdown=True)
+        except Exception as e:
+            self.assertIsInstance(e,ValueError)
+
     def test_double_evaluator(self):
         anomalies = ['step_uv']
         effects = []

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -431,6 +431,27 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],1)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],1/7)
 
+    def test_point_granularity_evaluation_with_breakdown(self):
+        formatted_series,anomaly_labels = _format_for_anomaly_detector(self.series1)
+        minmax1 = MinMaxAnomalyDetector()
+        flagged_series = _get_model_output([formatted_series],minmax1)
+        evaluation_results = _point_granularity_evaluation(flagged_series[0],anomaly_labels,breakdown=True)
+
+        self.assertIn('anomalies_count',evaluation_results.keys())
+        self.assertIn('anomalies_ratio',evaluation_results.keys())
+        self.assertIn('false_positives_count',evaluation_results.keys())
+        self.assertIn('false_positives_ratio',evaluation_results.keys())
+
+        self.assertIn('anomaly_1_anomaly_count',evaluation_results.keys())
+        self.assertIn('anomaly_1_anomaly_ratio',evaluation_results.keys())
+        self.assertIn('anomaly_2_anomaly_count',evaluation_results.keys())
+        self.assertIn('anomaly_2_anomaly_ratio',evaluation_results.keys())
+
+        self.assertAlmostEqual(evaluation_results['anomaly_1_anomaly_count'],2)
+        self.assertAlmostEqual(evaluation_results['anomaly_1_anomaly_ratio'],2/2)
+        self.assertAlmostEqual(evaluation_results['anomaly_2_anomaly_count'],1)
+        self.assertAlmostEqual(evaluation_results['anomaly_2_anomaly_ratio'],1/1)
+
     def test_series_granularity_evaluation(self):
         dataset = [self.series1]
         evaluator = Evaluator(test_data=dataset)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -572,7 +572,7 @@ class TestEvaluators(unittest.TestCase):
                 'detector_3': minmax3
                 }
         evaluator = Evaluator(test_data=dataset)
-        evaluation_results = evaluator.evaluate(models=models,granularity='data_point',breakdown=True)
+        evaluation_results = evaluator.evaluate(models=models,granularity='point',breakdown=True)
         self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],6)
         self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],7/8)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],4)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -478,6 +478,30 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],1)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],1)
 
+    def test_series_granularity_evaluation_with_breakdown(self):
+        series = generate_timeseries_df(entries=3, variables=2)
+        series['anomaly_label'] = [None,None,'anomaly_1']
+        formatted_series,anomaly_labels = _format_for_anomaly_detector(series)
+        minmax1 = MinMaxAnomalyDetector()
+        flagged_series = _get_model_output([formatted_series],minmax1)
+        evaluation_results = _series_granularity_evaluation(flagged_series[0],anomaly_labels,breakdown=True)
+
+        self.assertIn('anomalies_count',evaluation_results.keys())
+        self.assertIn('anomalies_ratio',evaluation_results.keys())
+        self.assertIn('false_positives_count',evaluation_results.keys())
+        self.assertIn('false_positives_ratio',evaluation_results.keys())
+        self.assertIn('anomaly_1_anomaly_count',evaluation_results.keys())
+        self.assertIn('anomaly_1_anomaly_ratio',evaluation_results.keys())
+        self.assertAlmostEqual(evaluation_results['anomaly_1_anomaly_count'],1)
+        self.assertAlmostEqual(evaluation_results['anomaly_1_anomaly_ratio'],1)
+
+        formatted_series1,anomaly_labels1 = _format_for_anomaly_detector(self.series1)
+        flagged_series1 = _get_model_output([formatted_series1],minmax1)
+        try:
+            evaluation_results = _point_granularity_evaluation(flagged_series1[0],anomaly_labels1,breakdown=True)
+        except Exception as e:
+            self.assertIsInstance(e,ValueError)
+
     def test_double_evaluator(self):
         anomalies = ['step_uv']
         effects = []

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -9,6 +9,7 @@ from ..evaluators import Evaluator
 from ..evaluators import _variable_granularity_evaluation
 from ..evaluators import _point_granularity_evaluation
 from ..evaluators import _series_granularity_evaluation
+from ..evaluators import _get_breakdown_info
 import unittest
 import pandas as pd
 import random as rnd
@@ -501,6 +502,44 @@ class TestEvaluators(unittest.TestCase):
             evaluation_results = _point_granularity_evaluation(flagged_series1[0],anomaly_labels1,breakdown=True)
         except Exception as e:
             self.assertIsInstance(e,ValueError)
+
+    def test_get_breakdown_info(self):
+        single_model_evaluation = { 'sample_1': {'anomalies_count': 3, 'anomalies_ratio': 1.5,
+                                                    'false_positives_count': 1, 
+                                                    'false_positives_ratio': 0.14,
+                                                    'spike_anomaly_count': 1,
+                                                    'spike_anomaly_ratio': 0.5},
+                                    'sample_2': {'anomalies_count': 3, 'anomalies_ratio': 1.5,
+                                                    'false_positives_count': 1, 
+                                                    'false_positives_ratio': 0.14,
+                                                    'spike_anomaly_count': 1,
+                                                    'spike_anomaly_ratio': 0.5,
+                                                    'step_anomaly_count': 2,
+                                                    'step_anomaly_ratio': 2/3
+                                                    },
+                                    'sample_3': {'anomalies_count': 3, 'anomalies_ratio': 1.5,
+                                                    'false_positives_count': 1,
+                                                    'false_positives_ratio': 0.14,
+                                                    'step_anomaly_count': 3,
+                                                    'step_anomaly_ratio': 1,
+                                                    'pattern_anomaly_count': 2,
+                                                    'pattern_anomaly_ratio': 0.5
+                                                    }
+        }
+        breakdown = _get_breakdown_info(single_model_evaluation)
+        self.assertIn('spike_anomaly_count',breakdown.keys())
+        self.assertIn('spike_anomaly_ratio',breakdown.keys())
+        self.assertIn('step_anomaly_count',breakdown.keys())
+        self.assertIn('step_anomaly_ratio',breakdown.keys())
+        self.assertIn('pattern_anomaly_count',breakdown.keys())
+        self.assertIn('pattern_anomaly_ratio',breakdown.keys())
+
+        self.assertAlmostEqual(breakdown['spike_anomaly_count'],2)
+        self.assertAlmostEqual(breakdown['spike_anomaly_ratio'],1/2)
+        self.assertAlmostEqual(breakdown['step_anomaly_count'],5)
+        self.assertAlmostEqual(breakdown['step_anomaly_ratio'],5/6)
+        self.assertAlmostEqual(breakdown['pattern_anomaly_count'],2)
+        self.assertAlmostEqual(breakdown['pattern_anomaly_ratio'],0.5)
 
     def test_double_evaluator(self):
         anomalies = ['step_uv']

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -578,10 +578,10 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],4)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],8/21)
 
-        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_count'],5)
-        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_ratio'],13/24)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_count'],4)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_ratio'],5/6)
         self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_count'],2)
-        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_ratio'],1/2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_ratio'],1)
 
     def test_double_evaluator(self):
         anomalies = ['step_uv']

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -563,10 +563,25 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_ratio'],1/2)
 
     def test_point_granularity_eval_with_breakdown(self):
-        pass
+        dataset = [self.series1, self.series2, self.series3]
+        minmax1 = MinMaxAnomalyDetector()
+        minmax2 = MinMaxAnomalyDetector()
+        minmax3 = MinMaxAnomalyDetector()
+        models={'detector_1': minmax1,
+                'detector_2': minmax2,
+                'detector_3': minmax3
+                }
+        evaluator = Evaluator(test_data=dataset)
+        evaluation_results = evaluator.evaluate(models=models,granularity='data_point',breakdown=True)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_count'],6)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomalies_ratio'],7/8)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],4)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],8/21)
 
-    def test_series_granularity_eval_with_breakdown(self):
-        pass
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_count'],5)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_anomaly_ratio'],13/24)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_count'],2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_anomaly_ratio'],1/2)
 
     def test_double_evaluator(self):
         anomalies = ['step_uv']

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -375,6 +375,36 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],1)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],1/(7*2))
 
+    def test_variable_granularity_evaluation_with_breakdown(self):
+        formatted_series,anomaly_labels = _format_for_anomaly_detector(self.series1)
+        minmax1 = MinMaxAnomalyDetector()
+        flagged_series = _get_model_output([formatted_series],minmax1)
+        evaluation_results = _variable_granularity_evaluation(flagged_series[0],anomaly_labels,breakdown=True)
+
+        self.assertIn('anomalies_count',evaluation_results.keys())
+        self.assertIn('anomalies_ratio',evaluation_results.keys())
+        self.assertIn('false_positives_count',evaluation_results.keys())
+        self.assertIn('false_positives_ratio',evaluation_results.keys())
+
+        self.assertIn('anomaly_1_anomaly_count',evaluation_results.keys())
+        self.assertIn('anomaly_1_anomaly_ratio',evaluation_results.keys())
+        self.assertIn('anomaly_2_anomaly_count',evaluation_results.keys())
+        self.assertIn('anomaly_2_anomaly_ratio',evaluation_results.keys())
+
+        self.assertAlmostEqual(evaluation_results['anomaly_1_anomaly_count'],3)
+        self.assertAlmostEqual(evaluation_results['anomaly_1_anomaly_ratio'],3/4)
+        self.assertAlmostEqual(evaluation_results['anomaly_2_anomaly_count'],1)
+        self.assertAlmostEqual(evaluation_results['anomaly_2_anomaly_ratio'],1/2)
+
+        formatted_series1,anomaly_labels1 = _format_for_anomaly_detector(self.series3)
+        flagged_series1 = _get_model_output([formatted_series1],minmax1)
+        evaluation_results1 = _variable_granularity_evaluation(flagged_series1[0],anomaly_labels1,breakdown=True)
+
+        self.assertNotIn('anomaly_1_anomaly_count',evaluation_results1.keys())
+        self.assertNotIn('anomaly_1_anomaly_ratio',evaluation_results1.keys())
+        self.assertNotIn('anomaly_2_anomaly_count',evaluation_results1.keys())
+        self.assertNotIn('anomaly_2_anomaly_ratio',evaluation_results1.keys())
+
     def test_point_granularity_evaluation(self):
         dataset = [self.series1]
         evaluator = Evaluator(test_data=dataset)


### PR DESCRIPTION
**BASED ON** #57 
The new argument `breakdown` of `evaluate()` allows to get informations about the detection performance of the model on each type of inserted anomaly.

If `breakdown = True`, the dictionary returned by the function above has a new part in addiction to the one already described in #57. 
For each anomaly type, the dictionary has the following 2 couples key-value:
 - `anomaly_type_true_positives_count`: $\sum_{i=1}^{N}N^{i}_{Ad}$
 
 -  `anomaly_type_true_positives_rate`: $\frac{1}{N_A}\sum_{i=1}^{N_A}\frac{N_{Ad}^{i}}{N^{i}_{Atot}}$. 
 
Given:
$N=$ n. series in the dataset
$N_A=$ n. series in the dataset with anomaly of type *A* 
$N_{Ad}^{i}=$ n. correctly detected anomalies of type *A* in the *i-th* series of the dataset
$N_{Atot}^{i}=$ n. inserted anomalies of type *A* in the *i-th* series of the dataset

To do an example,  consider the same dataset used in #57. 
The evaluation results with the 3 different granularities and breakdown are :
```
dataset = [series1, series2, series3]
minmax =  MinMaxAnomalyDetector()
models = {'my_model': minmax}
evaluator = Evaluator(dataset)
```
```
evaluation_result = evaluator.evaluate(models,granularity='variable',strategy='flags',breakdown=True)
{  'true_positives_count': 7
   'true_positives_rate': 0.5208333333333333
    'false_positives_count': 5
    'false_positives_ratio': 0.24603174603174602
    'anomaly_1_true_positives_count': 5
    'anomaly_1_true_positives_rate': 0.5416666666666666
    'anomaly_2_true_positives_count': 2
    'anomaly_2_true_positives_rate': 0.5 }
```
```
evaluation_result = evaluator.evaluate(models,granularity='point',strategy='flags',breakdown=True)
{  'true_positives_count': 6
   'true_positives_rate': 0.875
   'false_positives_count': 4
   'false_positives_ratio': 0.38095238095238093
   'anomaly_1_true_positives_count': 4
   'anomaly_1_true_positives_rate': 0.8333333333333333
   'anomaly_2_true_positives_count': 2
   'anomaly_2_true_positives_rate': 1.0 }
```
In case of `granularity = 'series'`,  it is necessary  a different example datset, because the breakdown with series granularity supports only datasets in which there is only 1 type of anomaly per series. 
Otherwise a `ValueError` is raised.
In the following, the outputs of the `MinMaxAnomalyDetector()` on each series of the new example dataset.
**series_1**
| timestamp                  | value_1  | value_2 | anomaly_label | value_1_anomaly | value_2_anomaly |
|----------------------------|----------|---------|----------------|------------------|------------------|
| 2025-06-10 14:00:00+00:00  | 0.000000 | 0.707107 | None     | 1             | 0            |
| 2025-06-10 15:00:00+00:00  | 0.841471 | 0.977061 | None     | 0            | 1             |
| 2025-06-10 16:00:00+00:00  | 0.909297 | 0.348710 | anomaly_1     | 1             | 1            |


**series_2**
| timestamp                  | value_1  | value_2 | anomaly_label | value_1_anomaly | value_2_anomaly |
|----------------------------|----------|---------|----------------|------------------|------------------|
| 2025-06-10 14:00:00+00:00  | 0.000000 | 0.707107 | anomaly_1     | 1             | 0            |
| 2025-06-10 15:00:00+00:00  | 0.841471 | 0.977061 | None     | 0            | 1             |
| 2025-06-10 16:00:00+00:00  | 0.909297 | 0.348710 | None     | 1             | 1            |


**series_3**
| timestamp                  | value_1  | value_2 | anomaly_label | value_1_anomaly | value_2_anomaly |
|----------------------------|----------|---------|----------------|------------------|------------------|
| 2025-06-10 14:00:00+00:00  | 0.000000 | 0.707107 | None     | 1             | 0            |
| 2025-06-10 15:00:00+00:00  | 0.841471 | 0.977061 | anomaly_2     | 0            | 1             |
| 2025-06-10 16:00:00+00:00  | 0.909297 | 0.348710 | None     | 1| 1            |

```
evaluation_result = evaluator.evaluate(models,granularity='series',strategy='flags',breakdown=True)
{  'true_positives_count': 3
   'true_positives_rate': 1.0
   'false_positives_count': 0
   'false_positives_ratio': 0.0
   'anomaly_1_true_positives_count': 2
   'anomaly_1_true_positives_rate': 1.0
   'anomaly_2_true_positives_count': 1
   'anomaly_2_true_positives_rate': 1.0}
```
This PR addresses and completes #56 