### PR TITLE
Feature: events strategy evaluation

### DIFF
--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -380,14 +380,15 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     evaluation_result = {}
     breakdown_info = {}
 
-    previous_anomaly_label = 0
+    previous_point_info = {'label': 0}
     for timestamp in flagged_timeseries_df.index:
         anomaly_label = anomaly_labels_df.loc[timestamp]
         flags_df = flagged_timeseries_df.filter(like='anomaly')
         # True if there is at least 1 variable detected as anomalous
         is_anomalous = flags_df.loc[timestamp].any()
-        if anomaly_label is not None and is_anomalous:
-            if anomaly_label != previous_anomaly_label:
+        point_info = {anomaly_label: is_anomalous}
+        if point_info != previous_point_info and is_anomalous:
+            if anomaly_label is not None:
                 detected_events_n += 1
 
                 breakdown_key = anomaly_label + '_true_positives_count'
@@ -396,12 +397,10 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
                 else:
                     breakdown_info[breakdown_key] = 1
 
-        elif anomaly_label is None and is_anomalous:
-            if anomaly_label != previous_anomaly_label:
+            else:
                 false_positives_n += 1
 
-        previous_timestamp = timestamp
-        previous_anomaly_label = anomaly_labels_df.loc[previous_timestamp]
+        previous_point_info = point_info
 
     evaluation_result['true_positives_count'] = detected_events_n
     if inserted_events_n:

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -371,7 +371,7 @@ def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df,break
         return one_series_evaluation_result
 
 def _variable_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
-    pass
+    raise NotImplementedError('Evaluation with events strategy and variable granularity not implemented')
 
 def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,breakdown=False):
     detected_events_n = 0

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -432,15 +432,20 @@ def _count_anomalous_events(anomaly_labels_df):
     previous_anomaly_label = None
     for timestamp in anomaly_labels_df.index:
         anomaly_label = anomaly_labels_df.loc[timestamp]
-        if anomaly_label is not None:
-            if anomaly_label != previous_anomaly_label:
+        if anomaly_label != previous_anomaly_label:
+            if anomaly_label is not None:
                 events_n += 1
-
                 key = anomaly_label
-                if key in event_type_counts.keys():
+                if anomaly_label in event_type_counts.keys():
                     event_type_counts[key] +=1
+                    event_time_slots[key].append(timestamp)
                 else:
                     event_type_counts[key] =1
+                    event_time_slots[key] = []
+                    event_time_slots[key].append(timestamp)
+
+            else:
+                event_time_slots[key].append(previous_timestamp)
 
         previous_timestamp = timestamp
         previous_anomaly_label = anomaly_labels_df.loc[previous_timestamp]

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -379,11 +379,12 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     inserted_events_n = _get_anomalous_events(anomaly_labels_df)
     evaluation_result = {}
 
-    previous_timestamp = None # non necessario secondo me
-    # previous_anomaly_label = None
+    previous_anomaly_label = None
     for timestamp in flagged_timeseries_df.index:
         anomaly_label = anomaly_labels_df.loc[timestamp]
-        is_anomalous = flagged_timeseries_df.loc[timestamp]
+        flags_df = flagged_timeseries_df.filter(like='_anomaly')
+        # True if there is at least 1 variable detected as anomalous
+        is_anomalous = flags_df.loc[timestamp].any()
         if anomaly_label is not None and is_anomalous:
             if anomaly_label != previous_anomaly_label:
                 detected_events_n += 1 
@@ -398,7 +399,7 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     evaluation_result['true_positives_count'] = detected_events_n
     evaluation_result['true_positives_rate'] = detected_events_n/inserted_events_n
     evaluation_result['false_positives_count'] = false_positives_n
-    evaluation_result['false_positives_count'] = false_positives_n/len(flagged_timeseries_df)
+    evaluation_result['false_positives_ratio'] = false_positives_n/len(flagged_timeseries_df)
     return evaluation_result
 
 def _series_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -379,7 +379,8 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     inserted_events_n = _get_anomalous_events(anomaly_labels_df)
     evaluation_result = {}
 
-    previous_timestamp = None
+    previous_timestamp = None # non necessario secondo me
+    # previous_anomaly_label = None
     for timestamp in flagged_timeseries_df.index:
         anomaly_label = anomaly_labels_df.loc[timestamp]
         is_anomalous = flagged_timeseries_df.loc[timestamp]
@@ -404,4 +405,13 @@ def _series_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=Fals
     pass
 
 def _get_anomalous_events(anomaly_labels_df):
-    pass
+    anomalous_events_n = 0
+    previous_anomaly_label = None
+    for timestamp in anomaly_labels_df.index:
+        anomaly_label = anomaly_labels_df.loc[timestamp]
+        if anomaly_label is not None:
+            if anomaly_label != previous_anomaly_label:
+                anomalous_events_n += 1
+        previous_timestamp = timestamp
+        previous_anomaly_label = anomaly_labels_df.loc[previous_timestamp]
+    return anomalous_events_n

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -426,21 +426,21 @@ def _series_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=Fals
     raise NotImplementedError('Evaluation with events strategy and series granularity not implemented')
 
 def _count_anomalous_events(anomaly_labels_df):
-    anomalous_events_n = 0
-    events_by_type_n = {}
+    events_n = 0
+    event_type_counts = {}
     previous_anomaly_label = None
     for timestamp in anomaly_labels_df.index:
         anomaly_label = anomaly_labels_df.loc[timestamp]
         if anomaly_label is not None:
             if anomaly_label != previous_anomaly_label:
-                anomalous_events_n += 1
+                events_n += 1
 
                 key = anomaly_label
-                if key in events_by_type_n.keys():
-                    events_by_type_n[key] +=1
+                if key in event_type_counts.keys():
+                    event_type_counts[key] +=1
                 else:
-                    events_by_type_n[key] =1
+                    event_type_counts[key] =1
 
         previous_timestamp = timestamp
         previous_anomaly_label = anomaly_labels_df.loc[previous_timestamp]
-    return anomalous_events_n, events_by_type_n
+    return events_n , event_type_counts

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -373,8 +373,35 @@ def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df,break
 def _variable_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
     pass
 
-def _point_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
-    pass
+def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,breakdown=False):
+    detected_events_n = 0
+    false_positives_n = 0
+    inserted_events_n = _get_anomalous_events(anomaly_labels_df)
+    evaluation_result = {}
+
+    previous_timestamp = None
+    for timestamp in flagged_timeseries_df.index:
+        anomaly_label = anomaly_labels_df.loc[timestamp]
+        is_anomalous = flagged_timeseries_df.loc[timestamp]
+        if anomaly_label is not None and is_anomalous:
+            if anomaly_label != previous_anomaly_label:
+                detected_events_n += 1 
+
+        elif anomaly_label is None and is_anomalous:
+            if anomaly_label != previous_anomaly_label:
+                false_positives_n += 1
+
+        previous_timestamp = timestamp
+        previous_anomaly_label = anomaly_labels_df.loc[previous_timestamp]
+
+    evaluation_result['true_positives_count'] = detected_events_n
+    evaluation_result['true_positives_rate'] = detected_events_n/inserted_events_n
+    evaluation_result['false_positives_count'] = false_positives_n
+    evaluation_result['false_positives_count'] = false_positives_n/len(flagged_timeseries_df)
+    return evaluation_result
 
 def _series_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
+    pass
+
+def _get_anomalous_events(anomaly_labels_df):
     pass

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -376,7 +376,7 @@ def _variable_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=Fa
 def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,breakdown=False):
     detected_events_n = 0
     false_positives_n = 0
-    inserted_events_n = _get_anomalous_events(anomaly_labels_df)
+    inserted_events_n = _count_anomalous_events(anomaly_labels_df)
     evaluation_result = {}
     breakdown_info = {}
 
@@ -415,14 +415,22 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
 def _series_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
     pass
 
-def _get_anomalous_events(anomaly_labels_df):
+def _count_anomalous_events(anomaly_labels_df):
     anomalous_events_n = 0
+    events_by_type_n = {}
     previous_anomaly_label = None
     for timestamp in anomaly_labels_df.index:
         anomaly_label = anomaly_labels_df.loc[timestamp]
         if anomaly_label is not None:
             if anomaly_label != previous_anomaly_label:
                 anomalous_events_n += 1
+
+                key = anomaly_label
+                if key in events_by_type_n.keys():
+                    events_by_type_n[key] +=1
+                else:
+                    events_by_type_n[key] =1
+
         previous_timestamp = timestamp
         previous_anomaly_label = anomaly_labels_df.loc[previous_timestamp]
-    return anomalous_events_n
+    return anomalous_events_n, events_by_type_n

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -419,7 +419,7 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
         return evaluation_result
 
 def _series_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
-    pass
+    raise NotImplementedError('Evaluation with events strategy and series granularity not implemented')
 
 def _count_anomalous_events(anomaly_labels_df):
     anomalous_events_n = 0

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -433,14 +433,16 @@ def _count_anomalous_events(anomaly_labels_df):
         if anomaly_label != previous_anomaly_label:
             if anomaly_label is not None:
                 events_n += 1
+                # To manage series with adjoining anomalies
+                if previous_anomaly_label is not None:
+                    event_time_slots[key].append(previous_timestamp)
                 key = anomaly_label
                 if anomaly_label in event_type_counts.keys():
                     event_type_counts[key] +=1
                     event_time_slots[key].append(timestamp)
                 else:
                     event_type_counts[key] =1
-                    event_time_slots[key] = []
-                    event_time_slots[key].append(timestamp)
+                    event_time_slots[key] = [timestamp]
 
             else:
                 event_time_slots[key].append(previous_timestamp)

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -408,7 +408,7 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     else:
         evaluation_result['true_positives_rate'] = None
     evaluation_result['false_positives_count'] = false_positives_n
-    evaluation_result['false_positives_ratio'] = false_positives_n/len(flagged_timeseries_df)
+    evaluation_result['false_positives_ratio'] = false_positives_n/len(anomaly_labels_df)
 
     for event in inserted_events_by_type.keys():
         breakdown_key = event + '_true_positives_count'

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -376,7 +376,7 @@ def _variable_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=Fa
 def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,breakdown=False):
     detected_events_n = 0
     false_positives_n = 0
-    inserted_events_n = _count_anomalous_events(anomaly_labels_df)
+    inserted_events_n,inserted_events_by_type = _count_anomalous_events(anomaly_labels_df)
     evaluation_result = {}
     breakdown_info = {}
 
@@ -407,6 +407,9 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     evaluation_result['true_positives_rate'] = detected_events_n/inserted_events_n
     evaluation_result['false_positives_count'] = false_positives_n
     evaluation_result['false_positives_ratio'] = false_positives_n/len(flagged_timeseries_df)
+
+    for key in inserted_events_by_type.keys():
+        breakdown_info[key + '_true_positives_rate'] = breakdown_info[key + '_true_positives_count']/inserted_events_by_type[key]
     if breakdown:
         return evaluation_result | breakdown_info
     else:

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -114,9 +114,6 @@ class Evaluator():
         return dataset_copies
 
     def evaluate(self,models={},granularity='point',strategy='flags',breakdown=False):
-        if strategy != 'flags':
-            raise NotImplementedError(f'Evaluation strategy {strategy} is not implemented')
-
         if not models:
             raise ValueError('There are no models to evaluate')
         if not self.test_data:
@@ -138,11 +135,23 @@ class Evaluator():
             flagged_dataset = _get_model_output(dataset_copies[j],model)
             for i,sample_df in enumerate(flagged_dataset):
                 if granularity == 'point':
-                    single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels_list[i],breakdown=breakdown)
+                    if strategy == 'flags':
+                        single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels_list[i],breakdown=breakdown)
+                    elif strategy == 'events':
+                        single_model_evaluation[f'sample_{i+1}'] = _point_eval_with_events_strategy(sample_df,anomaly_labels_df[i],breakdown=breakdown)
+
                 elif granularity == 'variable':
-                    single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
+                    if strategy == 'flags':
+                        single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
+                    elif strategy == 'events':
+                        single_model_evaluation[f'sample_{i+1}'] = _variable_eval_with_events_strategy(sample_df,anomaly_labels_df[i],breakdown=breakdown)
+
                 elif granularity == 'series':
-                    single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
+                    if strategy == 'flags':
+                        single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
+                    elif strategy == 'events':
+                        single_model_evaluation[f'sample_{i+1}'] = _series_eval_with_events_strategy(sample_df,anomaly_labels_df[i],breakdown=breakdown)
+
                 else:
                     raise ValueError(f'Unknown granularity {granularity}')
 
@@ -360,3 +369,12 @@ def _series_granularity_evaluation(flagged_timeseries_df,anomaly_labels_df,break
         return one_series_evaluation_result | breakdown_info
     else:
         return one_series_evaluation_result
+
+def _variable_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
+    pass
+
+def _point_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
+    pass
+
+def _series_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
+    pass

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -378,6 +378,7 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     false_positives_n = 0
     inserted_events_n = _get_anomalous_events(anomaly_labels_df)
     evaluation_result = {}
+    breakdown_info = {}
 
     previous_anomaly_label = None
     for timestamp in flagged_timeseries_df.index:
@@ -387,7 +388,13 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
         is_anomalous = flags_df.loc[timestamp].any()
         if anomaly_label is not None and is_anomalous:
             if anomaly_label != previous_anomaly_label:
-                detected_events_n += 1 
+                detected_events_n += 1
+
+                breakdown_key = anomaly_label + '_true_positives_count'
+                if breakdown_key in breakdown_info.keys():
+                    breakdown_info[breakdown_key] += 1
+                else:
+                    breakdown_info[breakdown_key] = 1
 
         elif anomaly_label is None and is_anomalous:
             if anomaly_label != previous_anomaly_label:
@@ -400,7 +407,10 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     evaluation_result['true_positives_rate'] = detected_events_n/inserted_events_n
     evaluation_result['false_positives_count'] = false_positives_n
     evaluation_result['false_positives_ratio'] = false_positives_n/len(flagged_timeseries_df)
-    return evaluation_result
+    if breakdown:
+        return evaluation_result | breakdown_info
+    else:
+        return evaluation_result
 
 def _series_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=False):
     pass

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -383,7 +383,7 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     previous_anomaly_label = 0
     for timestamp in flagged_timeseries_df.index:
         anomaly_label = anomaly_labels_df.loc[timestamp]
-        flags_df = flagged_timeseries_df.filter(like='_anomaly')
+        flags_df = flagged_timeseries_df.filter(like='anomaly')
         # True if there is at least 1 variable detected as anomalous
         is_anomalous = flags_df.loc[timestamp].any()
         if anomaly_label is not None and is_anomalous:
@@ -411,8 +411,13 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     evaluation_result['false_positives_count'] = false_positives_n
     evaluation_result['false_positives_ratio'] = false_positives_n/len(flagged_timeseries_df)
 
-    for key in inserted_events_by_type.keys():
-        breakdown_info[key + '_true_positives_rate'] = breakdown_info[key + '_true_positives_count']/inserted_events_by_type[key]
+    for event in inserted_events_by_type.keys():
+        breakdown_key = event + '_true_positives_count'
+        if breakdown_key in breakdown_info.keys():
+            breakdown_info[event + '_true_positives_rate'] = breakdown_info[breakdown_key]/inserted_events_by_type[event]
+        else:
+            breakdown_info[breakdown_key] = 0
+            breakdown_info[event + '_true_positives_rate'] = 0
     if breakdown:
         return evaluation_result | breakdown_info
     else:

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -376,7 +376,7 @@ def _variable_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=Fa
 def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,breakdown=False):
     detected_events_n = 0
     false_positives_n = 0
-    inserted_events_n,inserted_events_by_type = _count_anomalous_events(anomaly_labels_df)
+    events_n, event_type_counts, event_time_slots = _count_anomalous_events(anomaly_labels_df)
     evaluation_result = {}
     breakdown_info = {}
 
@@ -403,17 +403,17 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
         previous_point_info = point_info
 
     evaluation_result['true_positives_count'] = detected_events_n
-    if inserted_events_n:
-        evaluation_result['true_positives_rate'] = detected_events_n/inserted_events_n
+    if events_n:
+        evaluation_result['true_positives_rate'] = detected_events_n/events_n
     else:
         evaluation_result['true_positives_rate'] = None
     evaluation_result['false_positives_count'] = false_positives_n
     evaluation_result['false_positives_ratio'] = false_positives_n/len(anomaly_labels_df)
 
-    for event in inserted_events_by_type.keys():
+    for event in  event_type_counts.keys():
         breakdown_key = event + '_true_positives_count'
         if breakdown_key in breakdown_info.keys():
-            breakdown_info[event + '_true_positives_rate'] = breakdown_info[breakdown_key]/inserted_events_by_type[event]
+            breakdown_info[event + '_true_positives_rate'] = breakdown_info[breakdown_key]/ event_type_counts[event]
         else:
             breakdown_info[breakdown_key] = 0
             breakdown_info[event + '_true_positives_rate'] = 0
@@ -428,6 +428,7 @@ def _series_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=Fals
 def _count_anomalous_events(anomaly_labels_df):
     events_n = 0
     event_type_counts = {}
+    event_time_slots = {}
     previous_anomaly_label = None
     for timestamp in anomaly_labels_df.index:
         anomaly_label = anomaly_labels_df.loc[timestamp]
@@ -443,4 +444,4 @@ def _count_anomalous_events(anomaly_labels_df):
 
         previous_timestamp = timestamp
         previous_anomaly_label = anomaly_labels_df.loc[previous_timestamp]
-    return events_n , event_type_counts
+    return events_n , event_type_counts, event_time_slots

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -138,19 +138,19 @@ class Evaluator():
                     if strategy == 'flags':
                         single_model_evaluation[f'sample_{i+1}'] = _point_granularity_evaluation(sample_df,anomaly_labels_list[i],breakdown=breakdown)
                     elif strategy == 'events':
-                        single_model_evaluation[f'sample_{i+1}'] = _point_eval_with_events_strategy(sample_df,anomaly_labels_df[i],breakdown=breakdown)
+                        single_model_evaluation[f'sample_{i+1}'] = _point_eval_with_events_strategy(sample_df,anomaly_labels_list[i],breakdown=breakdown)
 
                 elif granularity == 'variable':
                     if strategy == 'flags':
                         single_model_evaluation[f'sample_{i+1}'] = _variable_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
                     elif strategy == 'events':
-                        single_model_evaluation[f'sample_{i+1}'] = _variable_eval_with_events_strategy(sample_df,anomaly_labels_df[i],breakdown=breakdown)
+                        single_model_evaluation[f'sample_{i+1}'] = _variable_eval_with_events_strategy(sample_df,anomaly_labels_list[i],breakdown=breakdown)
 
                 elif granularity == 'series':
                     if strategy == 'flags':
                         single_model_evaluation[f'sample_{i+1}'] = _series_granularity_evaluation(sample_df,anomaly_labels_list[i], breakdown = breakdown)
                     elif strategy == 'events':
-                        single_model_evaluation[f'sample_{i+1}'] = _series_eval_with_events_strategy(sample_df,anomaly_labels_df[i],breakdown=breakdown)
+                        single_model_evaluation[f'sample_{i+1}'] = _series_eval_with_events_strategy(sample_df,anomaly_labels_list[i],breakdown=breakdown)
 
                 else:
                     raise ValueError(f'Unknown granularity {granularity}')
@@ -404,7 +404,10 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
         previous_anomaly_label = anomaly_labels_df.loc[previous_timestamp]
 
     evaluation_result['true_positives_count'] = detected_events_n
-    evaluation_result['true_positives_rate'] = detected_events_n/inserted_events_n
+    if inserted_events_n:
+        evaluation_result['true_positives_rate'] = detected_events_n/inserted_events_n
+    else:
+        evaluation_result['true_positives_rate'] = None
     evaluation_result['false_positives_count'] = false_positives_n
     evaluation_result['false_positives_ratio'] = false_positives_n/len(flagged_timeseries_df)
 

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -446,5 +446,8 @@ def _count_anomalous_events(anomaly_labels_df):
                 event_time_slots[key].append(previous_timestamp)
 
         previous_timestamp = timestamp
-        previous_anomaly_label = anomaly_labels_df.loc[previous_timestamp]
+        previous_anomaly_label = anomaly_label
+    # To manage series ending with an anomaly
+    if previous_anomaly_label is not None:
+        event_time_slots[key].append(previous_timestamp)
     return events_n , event_type_counts, event_time_slots

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -405,8 +405,8 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
             is_detected = flags_df.loc[start:stop].any().any()
             if is_detected:
                 detected_anomaly_n +=1
-        breakdown_info[anomaly + 'true_positives_count'] = detected_anomaly_n
-        breakdown_info[anomaly + 'true_positives_rate'] = detected_anomaly_n/anomaly_n
+        breakdown_info[anomaly + '_true_positives_count'] = detected_anomaly_n
+        breakdown_info[anomaly + '_true_positives_rate'] = detected_anomaly_n/anomaly_n
         detected_events_n += detected_anomaly_n
 
     evaluation_result['true_positives_count'] = detected_events_n

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -376,6 +376,7 @@ def _variable_eval_with_events_strategy(sample_df,anomaly_labels_df,breakdown=Fa
 def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,breakdown=False):
     detected_events_n = 0
     false_positives_n = 0
+    total_events_n = 0
     events_n, event_type_counts, event_time_slots = _count_anomalous_events(anomaly_labels_df)
     evaluation_result = {}
     breakdown_info = {}
@@ -396,8 +397,8 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     evaluation_result['false_positives_ratio'] = false_positives_n/len(anomaly_labels_df)
 
     for anomaly, anomaly_time_slots in event_time_slots.items():
-        anomaly_n = len(anomaly_time_slots)//2
-        events_n += anomaly_n
+        anomaly_n = int(len(anomaly_time_slots))/2
+        total_events_n += anomaly_n
         detected_anomaly_n = 0
         for i in range(0,len(anomaly_time_slots),2):
             start = anomaly_time_slots[i]
@@ -411,7 +412,7 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
 
     evaluation_result['true_positives_count'] = detected_events_n
     if events_n:
-        evaluation_result['true_positives_rate'] = detected_events_n/events_n
+        evaluation_result['true_positives_rate'] = detected_events_n/total_events_n
     else:
         evaluation_result['true_positives_rate'] = None
 

--- a/ats/evaluators.py
+++ b/ats/evaluators.py
@@ -380,7 +380,7 @@ def _point_eval_with_events_strategy(flagged_timeseries_df,anomaly_labels_df,bre
     evaluation_result = {}
     breakdown_info = {}
 
-    previous_anomaly_label = None
+    previous_anomaly_label = 0
     for timestamp in flagged_timeseries_df.index:
         anomaly_label = anomaly_labels_df.loc[timestamp]
         flags_df = flagged_timeseries_df.filter(like='_anomaly')

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -660,7 +660,7 @@ class TestEvaluators(unittest.TestCase):
     def test_count_anomalous_events(self):
         humi_temp_generator = HumiTempTimeseriesGenerator()
         timeseries_df = humi_temp_generator.generate(include_effect_label=False, anomalies=['step_uv'])
-        anomalous_events,events_by_type = _count_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
+        anomalous_events,events_by_type, event_time_slots = _count_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
         self.assertEqual(anomalous_events,1)
         self.assertIsInstance(events_by_type,dict)
         self.assertEqual(events_by_type['step_uv'],1)
@@ -668,7 +668,7 @@ class TestEvaluators(unittest.TestCase):
     def test_count_anomalous_events_with_point_anomaly(self):
         humi_temp_generator = HumiTempTimeseriesGenerator()
         timeseries_df = humi_temp_generator.generate(include_effect_label=False, anomalies=['spike_uv'])
-        anomalous_events,events_by_type = _count_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
+        anomalous_events,events_by_type, event_time_slots = _count_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
         self.assertEqual(anomalous_events,1)
         self.assertEqual(events_by_type['spike_uv'],1)
 
@@ -742,7 +742,7 @@ class TestEvaluators(unittest.TestCase):
         evaluator = Evaluator(test_data = evaluation_dataset)
 
         series = evaluation_dataset[0]
-        anomalous_events_n, events_by_type_n = _count_anomalous_events(series.loc[:,'anomaly_label'])
+        anomalous_events_n, events_by_type_n, event_time_slots= _count_anomalous_events(series.loc[:,'anomaly_label'])
         evaluation_results = evaluator.evaluate(models=models,granularity='point',strategy='events',breakdown=False)
 
         for model in evaluation_results.keys():
@@ -769,7 +769,7 @@ class TestEvaluators(unittest.TestCase):
         # 1 step 
         # 0 pattern
         # 0 spike
-        anomalous_events_n, events_by_type_n = _count_anomalous_events(series_1.loc[:,'anomaly_label'])
+        anomalous_events_n, events_by_type_n ,event_time_slots= _count_anomalous_events(series_1.loc[:,'anomaly_label'])
         self.assertIn('step_mv',events_by_type_n.keys())
         self.assertEqual(events_by_type_n['step_mv'],1)
         self.assertEqual(anomalous_events_n,1)
@@ -781,7 +781,7 @@ class TestEvaluators(unittest.TestCase):
         # 1 step 
         # 0 pattern
         # 0 spike
-        anomalous_events_n_2, events_by_type_n_2 = _count_anomalous_events(series_2.loc[:,'anomaly_label'])
+        anomalous_events_n_2, events_by_type_n_2,event_time_slots_2 = _count_anomalous_events(series_2.loc[:,'anomaly_label'])
         self.assertIn('step_mv',events_by_type_n_2.keys())
         self.assertEqual(events_by_type_n_2['step_mv'],1)
         self.assertEqual(anomalous_events_n_2,1)
@@ -793,7 +793,7 @@ class TestEvaluators(unittest.TestCase):
         # 1 step 
         # 1 pattern
         # 1 spike
-        anomalous_events_n_3, events_by_type_n_3 = _count_anomalous_events(series_3.loc[:,'anomaly_label'])
+        anomalous_events_n_3, events_by_type_n_3 , event_time_slots_3= _count_anomalous_events(series_3.loc[:,'anomaly_label'])
         self.assertIn('step_mv',events_by_type_n_3.keys())
         self.assertIn('pattern_mv',events_by_type_n_3.keys())
         self.assertEqual(events_by_type_n_3['step_mv'],1)
@@ -814,7 +814,7 @@ class TestEvaluators(unittest.TestCase):
         # 1 step 
         # 0 pattern
         # 0 spike
-        anomalous_events_n, events_by_type_n = _count_anomalous_events(series.loc[:,'anomaly_label'])
+        anomalous_events_n, events_by_type_n ,event_time_slots= _count_anomalous_events(series.loc[:,'anomaly_label'])
         self.assertIn('step_mv',events_by_type_n.keys())
         self.assertEqual(events_by_type_n['step_mv'],1)
         self.assertEqual(anomalous_events_n,1)
@@ -858,7 +858,7 @@ class TestEvaluators(unittest.TestCase):
         # 1 step 
         # 0 pattern
         # 0 spike
-        anomalous_events_n, events_by_type_n = _count_anomalous_events(series.loc[:,'anomaly_label'])
+        anomalous_events_n, events_by_type_n , event_time_slots= _count_anomalous_events(series.loc[:,'anomaly_label'])
         self.assertIn('step_mv',events_by_type_n.keys())
         self.assertEqual(events_by_type_n['step_mv'],1)
         self.assertEqual(anomalous_events_n,1)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -736,8 +736,7 @@ class TestEvaluators(unittest.TestCase):
                                                 time_span = '90D', max_anomalies_per_series = 3, 
                                                 anomalies_ratio = 1.0, auto_repeat_anomalies=True)
         models = {'minmax': MinMaxAnomalyDetector(), 
-                  'nhar': NHARAnomalyDetector(), 
-                  'p_avg': PeriodicAverageAnomalyDetector()
+                  'nhar': NHARAnomalyDetector()
                   }
         evaluator = Evaluator(test_data = evaluation_dataset)
 

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -710,4 +710,4 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['true_positives_count'],6)
         self.assertAlmostEqual(evaluation_results['detector_1']['true_positives_rate'],7/8)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],2)
-        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],8/21)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],10/(21*3))

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -12,6 +12,7 @@ from ..evaluators import _series_granularity_evaluation
 from ..evaluators import _get_breakdown_info
 from ..anomaly_detectors.stat.periodic_average import PeriodicAverageAnomalyDetector
 from ..evaluators import _get_anomalous_events
+from ..evaluators import _count_anomalous_events
 from ..evaluators import _point_eval_with_events_strategy
 
 import unittest
@@ -655,17 +656,20 @@ class TestEvaluators(unittest.TestCase):
         models={'paverage': PeriodicAverageAnomalyDetector() }
         evaluation_results = evaluator.evaluate(models=models,granularity='point')
 
-    def test_get_anomalous_events(self):
+    def test_count_anomalous_events(self):
         humi_temp_generator = HumiTempTimeseriesGenerator()
         timeseries_df = humi_temp_generator.generate(include_effect_label=False, anomalies=['step_uv'])
-        anomalous_events = _get_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
+        anomalous_events,events_by_type = _count_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
         self.assertEqual(anomalous_events,1)
+        self.assertIsInstance(events_by_type,dict)
+        self.assertEqual(events_by_type['step_uv'],1)
 
-    def test_get_anomalous_events_with_point_anomaly(self):
+    def test_count_anomalous_events_with_point_anomaly(self):
         humi_temp_generator = HumiTempTimeseriesGenerator()
         timeseries_df = humi_temp_generator.generate(include_effect_label=False, anomalies=['spike_uv'])
-        anomalous_events = _get_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
+        anomalous_events,events_by_type = _count_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
         self.assertEqual(anomalous_events,1)
+        self.assertEqual(events_by_type['spike_uv'],1)
 
     def test_point_eval_with_events_strategy(self):
         # model output

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -11,6 +11,8 @@ from ..evaluators import _point_granularity_evaluation
 from ..evaluators import _series_granularity_evaluation
 from ..evaluators import _get_breakdown_info
 from ..anomaly_detectors.stat.periodic_average import PeriodicAverageAnomalyDetector
+from ..evaluators import _get_anomalous_events
+
 import unittest
 import pandas as pd
 import random as rnd
@@ -652,3 +654,14 @@ class TestEvaluators(unittest.TestCase):
         models={'paverage': PeriodicAverageAnomalyDetector() }
         evaluation_results = evaluator.evaluate(models=models,granularity='point')
 
+    def test_get_anomalous_events(self):
+        humi_temp_generator = HumiTempTimeseriesGenerator()
+        timeseries_df = humi_temp_generator.generate(include_effect_label=False, anomalies=['step_uv'])
+        anomalous_events = _get_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
+        self.assertEqual(anomalous_events,1)
+
+    def test_get_anomalous_events_with_point_anomaly(self):
+        humi_temp_generator = HumiTempTimeseriesGenerator()
+        timeseries_df = humi_temp_generator.generate(include_effect_label=False, anomalies=['spike_uv'])
+        anomalous_events = _get_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
+        self.assertEqual(anomalous_events,1)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -15,6 +15,7 @@ from ats.anomaly_detectors.stat.robust import NHARAnomalyDetector
 from ..evaluators import _count_anomalous_events
 from ..evaluators import _point_eval_with_events_strategy
 from ats.dataset_generators import HumiTempDatasetGenerator
+from ..utils import ensure_full_reproducibility
 
 import unittest
 import pandas as pd
@@ -29,9 +30,7 @@ logger.setup()
 class TestEvaluators(unittest.TestCase):
 
     def setUp(self):
-
-        rnd.seed(123)
-        np.random.seed(123)
+        ensure_full_reproducibility(123)
 
         self.series1 = generate_timeseries_df(entries=5, variables=2)
         self.series1['anomaly_label'] = [None, 'anomaly_2', 'anomaly_1', None, 'anomaly_1']
@@ -950,7 +949,7 @@ class TestEvaluators(unittest.TestCase):
 
         self.assertEqual(evaluation['nhar']['true_positives_count'],2)
         self.assertAlmostEqual(evaluation['nhar']['true_positives_rate'],1)
-        #self.assertEqual(evaluation['nhar']['false_positives_count'],5)
-        #self.assertAlmostEqual(evaluation['nhar']['false_positives_ratio'],5/120)
+        self.assertEqual(evaluation['nhar']['false_positives_count'],6)
+        self.assertAlmostEqual(evaluation['nhar']['false_positives_ratio'],6/120)
         self.assertEqual(evaluation['nhar']['spike_mv_true_positives_count'],2)
         self.assertAlmostEqual(evaluation['nhar']['spike_mv_true_positives_rate'],1)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -12,6 +12,7 @@ from ..evaluators import _series_granularity_evaluation
 from ..evaluators import _get_breakdown_info
 from ..anomaly_detectors.stat.periodic_average import PeriodicAverageAnomalyDetector
 from ..evaluators import _get_anomalous_events
+from ..evaluators import _point_eval_with_events_strategy
 
 import unittest
 import pandas as pd
@@ -665,3 +666,16 @@ class TestEvaluators(unittest.TestCase):
         timeseries_df = humi_temp_generator.generate(include_effect_label=False, anomalies=['spike_uv'])
         anomalous_events = _get_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
         self.assertEqual(anomalous_events,1)
+
+    def test_point_eval_with_events_strategy(self):
+        # model output
+        series = generate_timeseries_df(entries=6, variables=1)
+        series['value_anomaly'] = [0,1,1,1,1,1]
+
+        anomaly_labels = pd.Series([None, 'anomaly_1', 'anomaly_1', None, None,'anomaly_1'])
+        anomaly_labels.index = series.index
+        evaluation_result = _point_eval_with_events_strategy(series,anomaly_labels)
+        self.assertAlmostEqual(evaluation_result['true_positives_count'],2)
+        self.assertAlmostEqual(evaluation_result['true_positives_rate'],2/2)
+        self.assertAlmostEqual(evaluation_result['false_positives_count'],1)
+        self.assertAlmostEqual(evaluation_result['false_positives_ratio'],1/6)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -736,7 +736,8 @@ class TestEvaluators(unittest.TestCase):
                                                 time_span = '90D', max_anomalies_per_series = 3, 
                                                 anomalies_ratio = 1.0, auto_repeat_anomalies=True)
         models = {'minmax': MinMaxAnomalyDetector(), 
-                  'nhar': NHARAnomalyDetector()
+                  'nhar': NHARAnomalyDetector(),
+                  'p_avg': PeriodicAverageAnomalyDetector()
                   }
         evaluator = Evaluator(test_data = evaluation_dataset)
 

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -664,6 +664,11 @@ class TestEvaluators(unittest.TestCase):
         self.assertEqual(anomalous_events,1)
         self.assertIsInstance(events_by_type,dict)
         self.assertEqual(events_by_type['step_uv'],1)
+        '''for timestamp in timeseries_df.index:
+            print(f"{timestamp}  {timeseries_df.loc[timestamp,'anomaly_label']}")'''
+        # 1973-05-25 01:17:00+00:00 - 1973-06-01 02:02:00+00:00
+        self.assertEqual(event_time_slots['step_uv'][0],pd.Timestamp('1973-05-25 01:17:00+00:00'))
+        self.assertEqual(event_time_slots['step_uv'][1],pd.Timestamp('1973-06-01 02:02:00+00:00'))
 
     def test_count_anomalous_events_with_point_anomaly(self):
         humi_temp_generator = HumiTempTimeseriesGenerator()
@@ -671,6 +676,11 @@ class TestEvaluators(unittest.TestCase):
         anomalous_events,events_by_type, event_time_slots = _count_anomalous_events(timeseries_df.loc[:,'anomaly_label'])
         self.assertEqual(anomalous_events,1)
         self.assertEqual(events_by_type['spike_uv'],1)
+        '''for timestamp in timeseries_df.index:
+            print(f"{timestamp}  {timeseries_df.loc[timestamp,'anomaly_label']}")'''
+        # 1973-05-02 15:47:00+00:00 - 1973-05-02 15:47:00+00:00
+        self.assertEqual(event_time_slots['spike_uv'][0],pd.Timestamp('1973-05-02 15:47:00+00:00'))
+        self.assertEqual(event_time_slots['spike_uv'][1],pd.Timestamp('1973-05-02 15:47:00+00:00'))
 
     def test_point_eval_with_events_strategy(self):
         # model output
@@ -788,7 +798,7 @@ class TestEvaluators(unittest.TestCase):
 
         series_3 = evaluation_dataset[2]
         '''for timestamp in series_3.index:
-            print(series_3.loc[timestamp,'anomaly_label'])'''
+            print(f"{timestamp}  {series_3.loc[timestamp,'anomaly_label']}")'''
         # series_3
         # 1 step 
         # 1 pattern
@@ -800,6 +810,15 @@ class TestEvaluators(unittest.TestCase):
         self.assertEqual(events_by_type_n_3['pattern_mv'],1)
         self.assertEqual(events_by_type_n_3['spike_mv'],1)
         self.assertEqual(anomalous_events_n_3,3)
+        # spike : 1976-01-02 14:50:00+00:00 - 1976-01-02 14:50:00+00:00
+        self.assertEqual(event_time_slots_3['spike_mv'][0],pd.Timestamp('1976-01-02 14:50:00+00:00'))
+        self.assertEqual(event_time_slots_3['spike_mv'][1],pd.Timestamp('1976-01-02 14:50:00+00:00'))
+         # step : 1975-12-25 16:50:00+00:00 - 1976-01-02 03:50:00+00:00
+        self.assertEqual(event_time_slots_3['step_mv'][0],pd.Timestamp('1975-12-25 16:50:00+00:00'))
+        self.assertEqual(event_time_slots_3['step_mv'][1],pd.Timestamp('1976-01-02 03:50:00+00:00'))
+         # pattern : 1975-11-13 04:50:00+00:00 - 1975-11-23 08:50:00+00:00
+        self.assertEqual(event_time_slots_3['pattern_mv'][0],pd.Timestamp('1975-11-13 04:50:00+00:00'))
+        self.assertEqual(event_time_slots_3['pattern_mv'][1],pd.Timestamp('1975-11-23 08:50:00+00:00'))
 
     def test_event_eval_on_p_avg(self):
         anomalies = ['step_mv']

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -695,3 +695,19 @@ class TestEvaluators(unittest.TestCase):
         self.assertIn('anomaly_1_true_positives_count',evaluation_result.keys())
         self.assertAlmostEqual(evaluation_result['anomaly_1_true_positives_count'],2)
         self.assertAlmostEqual(evaluation_result['anomaly_1_true_positives_rate'],1)
+
+    def test_eval_point_granularity_events_strategy(self):
+        dataset = [self.series1, self.series2, self.series3]
+        minmax1 = MinMaxAnomalyDetector()
+        minmax2 = MinMaxAnomalyDetector()
+        minmax3 = MinMaxAnomalyDetector()
+        models={'detector_1': minmax1,
+                'detector_2': minmax2,
+                'detector_3': minmax3
+                }
+        evaluator = Evaluator(test_data=dataset)
+        evaluation_results = evaluator.evaluate(models=models,granularity='point',strategy='events')
+        self.assertAlmostEqual(evaluation_results['detector_1']['true_positives_count'],6)
+        self.assertAlmostEqual(evaluation_results['detector_1']['true_positives_rate'],7/8)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],8/21)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -694,3 +694,4 @@ class TestEvaluators(unittest.TestCase):
         evaluation_result = _point_eval_with_events_strategy(series,anomaly_labels,breakdown=True)
         self.assertIn('anomaly_1_true_positives_count',evaluation_result.keys())
         self.assertAlmostEqual(evaluation_result['anomaly_1_true_positives_count'],2)
+        self.assertAlmostEqual(evaluation_result['anomaly_1_true_positives_rate'],1)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -710,3 +710,18 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_results['detector_1']['true_positives_rate'],7/8)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],2)
         self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],10/(21*3))
+
+    def test_eval_point_granularity_events_strategy_with_breakdown(self):
+        dataset = [self.series1, self.series2, self.series3]
+        minmax = MinMaxAnomalyDetector()
+        models={'detector_1': minmax}
+        evaluator = Evaluator(test_data=dataset)
+        evaluation_results = evaluator.evaluate(models=models,granularity='point',strategy='events',breakdown=True)
+        self.assertAlmostEqual(evaluation_results['detector_1']['true_positives_count'],6)
+        self.assertAlmostEqual(evaluation_results['detector_1']['true_positives_rate'],7/8)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_count'],2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['false_positives_ratio'],10/(21*3))
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_true_positives_count'],4)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_1_true_positives_rate'],5/6)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_true_positives_count'],2)
+        self.assertAlmostEqual(evaluation_results['detector_1']['anomaly_2_true_positives_rate'],1)

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -11,7 +11,6 @@ from ..evaluators import _point_granularity_evaluation
 from ..evaluators import _series_granularity_evaluation
 from ..evaluators import _get_breakdown_info
 from ..anomaly_detectors.stat.periodic_average import PeriodicAverageAnomalyDetector
-from ..evaluators import _get_anomalous_events
 from ..evaluators import _count_anomalous_events
 from ..evaluators import _point_eval_with_events_strategy
 

--- a/ats/tests/test_evaluators.py
+++ b/ats/tests/test_evaluators.py
@@ -679,3 +679,14 @@ class TestEvaluators(unittest.TestCase):
         self.assertAlmostEqual(evaluation_result['true_positives_rate'],2/2)
         self.assertAlmostEqual(evaluation_result['false_positives_count'],1)
         self.assertAlmostEqual(evaluation_result['false_positives_ratio'],1/6)
+
+    def test_point_eval_with_events_strategy_and_breakdown(self):
+        # model output
+        series = generate_timeseries_df(entries=6, variables=1)
+        series['value_anomaly'] = [0,1,1,1,1,1]
+
+        anomaly_labels = pd.Series([None, 'anomaly_1', 'anomaly_1', None, None,'anomaly_1'])
+        anomaly_labels.index = series.index
+        evaluation_result = _point_eval_with_events_strategy(series,anomaly_labels,breakdown=True)
+        self.assertIn('anomaly_1_true_positives_count',evaluation_result.keys())
+        self.assertAlmostEqual(evaluation_result['anomaly_1_true_positives_count'],2)


### PR DESCRIPTION
#62 is addressed
Two evaluation strategy are available:
- `strategy='flags'`: anomalies are identified at the data-point level, based on the anomaly flag associated
- `strategy='events'`: anomalies are identified at the event level, i.e. an anomalous event represents a group of anomalous data points.
At the moment, only the point granularity is implemented for the events strategy. 
About the series granularity: with this granularity, the evaluation does not distinguish between the strategies (as already discussed) 
