### PR TITLE
Fix: dataset generator anomalies error handling

### DIFF
--- a/ats/dataset_generators.py
+++ b/ats/dataset_generators.py
@@ -165,15 +165,12 @@ class HumiTempDatasetGenerator(DatasetGenerator):
             random_applied_effects = rnd.sample(random_effects, rnd.randint(0, len(random_effects))) 
             applied_effects = list(set(effects + random_applied_effects))
             
-            try:
-                series = self._generate_series(sampling_interval=self.sampling_interval,
+            series = self._generate_series(sampling_interval=self.sampling_interval,
                                         sub_time_span=sub_time_span,
                                         anomalies=anomalies_for_group,
                                         effects=applied_effects,
                                         max_anomalies_per_series=max_anomalies_per_series)
-            except Exception as e:
-                logger.error(f"Error generating series {i+1}: {e}")
-                continue
+
             logger.info(f"Generated dataset {len(dataset)+1} with effects: {applied_effects} and anomalies: {anomalies_for_group}  ")
             dataset.append(series)
     

--- a/ats/tests/test_dataset_generators.py
+++ b/ats/tests/test_dataset_generators.py
@@ -50,6 +50,20 @@ class TestDatasetGenerator(unittest.TestCase):
         with self.assertRaises(ValueError):
             generator.generate(effects=[],anomalies=['clouds'])
         generator.generate(effects=['clouds'],anomalies=['clouds','spike_mv'])  # Should not raise
+        with self.assertRaises(ValueError):
+            generator.generate(effects=['noise'],anomalies=['AAAAAA'])
+
+    def test_step_anomaly_error(self):
+        generator = HumiTempDatasetGenerator()
+        with self.assertRaises(NotImplementedError):
+            generator.generate(
+                n_series=5,
+                time_span='10D',
+                effects=['noise'],
+                anomalies=['step_uv'],
+                auto_repeat_anomalies=False,
+                anomalies_ratio=1.0
+            )  
 
     #def test_generate_random_effects(self):
       #  generator = HumiTempDatasetGenerator()


### PR DESCRIPTION
This PR remove the try-except around the self._generate_series() call. In this way is directly raised the error from HumiTempTimeseriesGenerator to handle non-existent  anomalies (Address #71).

The error raising was verified by adding appropriate test to test_dataset_generators.py